### PR TITLE
fix(login-wallet): validate chain id before challenge request

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -30,6 +30,7 @@ import { usageByKey } from "./commands/usage-by-key.js";
 import { usageByModel } from "./commands/usage-by-model.js";
 import { usageSummary } from "./commands/usage-summary.js";
 import { usageTimeline } from "./commands/usage-timeline.js";
+import { CliError } from "./lib/api.js";
 import { DEFAULT_SESSION_FILE } from "./lib/session.js";
 
 const program = new Command();
@@ -38,6 +39,15 @@ const DEFAULT_CLOUD_CLAW_BASE_URL =
 
 function collectOptionValues(value: string, previous?: string[]): string[] {
   return [...(previous ?? []), value];
+}
+
+function parsePositiveIntegerOption(value: string, optionName: string): number {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || !Number.isInteger(parsed) || parsed <= 0) {
+    throw new CliError(`${optionName} must be a positive integer.`);
+  }
+
+  return parsed;
 }
 
 program
@@ -65,7 +75,7 @@ program
       walletAddress: options.walletAddress,
       privateKey: options.privateKey,
       privateKeyEnv: options.privateKeyEnv,
-      chainId: Number(options.chainId),
+      chainId: parsePositiveIntegerOption(options.chainId, "--chain-id"),
       prepare: Boolean(options.prepare),
       nonce: options.nonce,
       signature: options.signature,

--- a/src/commands/login-wallet.ts
+++ b/src/commands/login-wallet.ts
@@ -31,6 +31,12 @@ export interface LoginWalletOptions {
   sessionFile: string;
 }
 
+function validateChainId(chainId: number): void {
+  if (!Number.isFinite(chainId) || !Number.isInteger(chainId) || chainId <= 0) {
+    throw new CliError("Chain ID must be a positive integer.");
+  }
+}
+
 export async function loginWallet(options: LoginWalletOptions): Promise<void> {
   const baseUrl = normalizeBaseUrl(options.baseUrl);
   const walletAddress = options.walletAddress.trim();
@@ -73,6 +79,8 @@ export async function loginWallet(options: LoginWalletOptions): Promise<void> {
     );
     return;
   }
+
+  validateChainId(options.chainId);
 
   const challenge = await requestJson<CryptoChallengeResponse>({
     method: "POST",


### PR DESCRIPTION
## Summary
- validate \ as a positive integer during CLI parsing
- add a second validation guard inside \ to reject invalid programmatic inputs
- fail fast locally instead of sending malformed challenge payloads to the Portal API

## Testing
- npm run typecheck
- npm run build
- node dist/cli.js login-wallet --wallet-address 0x0000000000000000000000000000000000000001 --base-url http://127.0.0.1:9 --chain-id abc --prepare
- node dist/cli.js login-wallet --wallet-address 0x0000000000000000000000000000000000000001 --base-url http://127.0.0.1:9 --chain-id -1 --prepare
- node dist/cli.js login-wallet --wallet-address 0x0000000000000000000000000000000000000001 --base-url http://127.0.0.1:9 --chain-id 1.5 --prepare
- node -e "import('./dist/commands/login-wallet.js').then(async (m) => { try { await m.loginWallet({ baseUrl: 'http://127.0.0.1:9', walletAddress: '0x0000000000000000000000000000000000000001', privateKeyEnv: 'ALTLLM_WALLET_PRIVATE_KEY', chainId: Number.NaN, sessionFile: '/tmp/altllm-session.json' }); process.exit(1); } catch (error) { const message = error instanceof Error ? error.message : String(error); console.log(message); process.exit(message === 'Chain ID must be a positive integer.' ? 0 : 1); } })"

Closes #17.