### PR TITLE
fix(cloud-claw): wait for stop completion before restart

### DIFF
--- a/skills/cloud-claw-manage-vm/SKILL.md
+++ b/skills/cloud-claw-manage-vm/SKILL.md
@@ -42,7 +42,7 @@ The implementation source of truth is the sibling repository:
   - or full names with `openclaw-`, `picoclaw-`, `aintern-`
 - `restart` is not a dedicated API endpoint. Treat it as:
   - stop
-  - wait for completion
+  - poll deployment status until it reaches a stopped state such as `stopped` or `terminated`
   - start
 - `renew` and `auto-renew` are user-facing billing operations, not infra-only actions.
 - Prefer the local `altllm cloud-claw-*` commands over raw HTTP.

--- a/src/commands/cloud-claw-lifecycle.ts
+++ b/src/commands/cloud-claw-lifecycle.ts
@@ -1,3 +1,4 @@
+import { CliError } from "../lib/api.js";
 import { requestCloudClawJson, validateDeploymentName, writeJson } from "../lib/cloud-claw.js";
 import { DEFAULT_SESSION_FILE } from "../lib/session.js";
 
@@ -10,6 +11,22 @@ export interface CloudClawLifecycleOptions {
 
 export interface CloudClawAutoRenewOptions extends CloudClawLifecycleOptions {
   enabled: boolean;
+}
+
+interface CloudClawDeploymentSnapshot {
+  status?: string;
+}
+
+interface CloudClawDeploymentResponse {
+  deployment?: CloudClawDeploymentSnapshot;
+}
+
+const RESTART_READY_STATUSES = new Set(["stopped", "terminated", "suspended"]);
+const RESTART_POLL_INTERVAL_MS = 2_000;
+const RESTART_STOP_TIMEOUT_MS = 120_000;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 async function postLifecycle(
@@ -25,6 +42,49 @@ async function postLifecycle(
   });
 
   writeJson(result);
+}
+
+async function fetchDeploymentStatus(
+  options: CloudClawLifecycleOptions,
+  name: string
+): Promise<string> {
+  const result = await requestCloudClawJson<CloudClawDeploymentResponse>({
+    method: "GET",
+    path: `/api/vm/deployments/${name}`,
+    baseUrl: options.baseUrl,
+    sessionFile: options.sessionFile || DEFAULT_SESSION_FILE,
+    forceSso: options.forceSso,
+  });
+
+  const status = result.deployment?.status?.trim().toLowerCase();
+  if (!status) {
+    throw new CliError(`Cloud Claw deployment status missing for ${name}.`);
+  }
+
+  return status;
+}
+
+async function waitForRestartReady(
+  options: CloudClawLifecycleOptions,
+  name: string
+): Promise<string> {
+  const startedAt = Date.now();
+  let lastStatus = "";
+
+  while (true) {
+    lastStatus = await fetchDeploymentStatus(options, name);
+    if (RESTART_READY_STATUSES.has(lastStatus)) {
+      return lastStatus;
+    }
+
+    if (Date.now() - startedAt >= RESTART_STOP_TIMEOUT_MS) {
+      throw new CliError(
+        `Timed out waiting for Cloud Claw deployment ${name} to stop before restart. Last observed status: ${lastStatus}.`
+      );
+    }
+
+    await sleep(RESTART_POLL_INTERVAL_MS);
+  }
 }
 
 export async function cloudClawStart(options: CloudClawLifecycleOptions): Promise<void> {
@@ -53,13 +113,15 @@ export async function cloudClawDelete(options: CloudClawLifecycleOptions): Promi
 
 export async function cloudClawRestart(options: CloudClawLifecycleOptions): Promise<void> {
   const name = validateDeploymentName(options.name);
-  await requestCloudClawJson<Record<string, unknown>>({
+  const stopResult = await requestCloudClawJson<Record<string, unknown>>({
     method: "POST",
     path: `/api/vm/deployments/${name}/stop`,
     baseUrl: options.baseUrl,
     sessionFile: options.sessionFile || DEFAULT_SESSION_FILE,
     forceSso: options.forceSso,
   });
+
+  const restartReadyStatus = await waitForRestartReady(options, name);
 
   const result = await requestCloudClawJson<Record<string, unknown>>({
     method: "POST",
@@ -73,6 +135,8 @@ export async function cloudClawRestart(options: CloudClawLifecycleOptions): Prom
     ok: true,
     restarted: true,
     name,
+    stopResult,
+    restartReadyStatus,
     startResult: result,
   });
 }


### PR DESCRIPTION
## Summary
- make `cloud-claw-restart` wait for stop completion before issuing `start`
- poll deployment status until it reaches a stopped state such as `stopped`, `terminated`, or `suspended`
- fail clearly if the stop phase does not complete before timeout
- tighten the Cloud Claw skill doc so the documented restart contract matches the implemented wait behavior

## Testing
- `npm run typecheck`
- `npm run build`

## Notes
I did not run a live restart against a real VM in this branch because there was no active deployment available for a no-cost verification path.

Closes #12.
