### PR TITLE
fix(payments): validate polling interval and timeout

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -50,6 +50,15 @@ function parsePositiveIntegerOption(value: string, optionName: string): number {
   return parsed;
 }
 
+function parsePositiveNumberOption(value: string, optionName: string): number {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new CliError(`${optionName} must be a positive number.`);
+  }
+
+  return parsed;
+}
+
 program
   .name("altllm")
   .description("CLI for AltLLM Portal auth, API key management, billing, and payments");
@@ -475,8 +484,11 @@ program
       redirectUrl: options.redirectUrl,
       sessionFile: options.sessionFile,
       wait: Boolean(options.wait),
-      pollIntervalSeconds: Number(options.pollInterval),
-      timeoutSeconds: Number(options.timeout),
+      pollIntervalSeconds: parsePositiveNumberOption(
+        options.pollInterval,
+        "--poll-interval"
+      ),
+      timeoutSeconds: parsePositiveNumberOption(options.timeout, "--timeout"),
     });
   });
 
@@ -494,8 +506,11 @@ program
       baseUrl: options.baseUrl,
       sessionFile: options.sessionFile,
       wait: Boolean(options.wait),
-      pollIntervalSeconds: Number(options.pollInterval),
-      timeoutSeconds: Number(options.timeout),
+      pollIntervalSeconds: parsePositiveNumberOption(
+        options.pollInterval,
+        "--poll-interval"
+      ),
+      timeoutSeconds: parsePositiveNumberOption(options.timeout, "--timeout"),
     });
   });
 
@@ -517,8 +532,11 @@ program
       privateKey: options.privateKey,
       privateKeyEnv: options.privateKeyEnv,
       wait: Boolean(options.wait),
-      pollIntervalSeconds: Number(options.pollInterval),
-      timeoutSeconds: Number(options.timeout),
+      pollIntervalSeconds: parsePositiveNumberOption(
+        options.pollInterval,
+        "--poll-interval"
+      ),
+      timeoutSeconds: parsePositiveNumberOption(options.timeout, "--timeout"),
     });
   });
 

--- a/src/commands/pay-payment-link.ts
+++ b/src/commands/pay-payment-link.ts
@@ -5,6 +5,7 @@ import {
   fetchPaymentLinkStatus,
   formatPaymentLinkRecord,
   isTerminalPaymentLinkStatus,
+  validatePaymentPollingOptions,
   waitForPaymentLinkSettlement,
 } from "./topup-crypto.js";
 
@@ -20,6 +21,13 @@ export interface PayPaymentLinkOptions {
 }
 
 export async function payPaymentLink(options: PayPaymentLinkOptions): Promise<void> {
+  if (options.wait) {
+    validatePaymentPollingOptions({
+      pollIntervalSeconds: options.pollIntervalSeconds,
+      timeoutSeconds: options.timeoutSeconds,
+    });
+  }
+
   const session = await loadSession(options.sessionFile || DEFAULT_SESSION_FILE);
   const baseUrl = normalizeBaseUrl(options.baseUrl || session.baseUrl);
   const link = await fetchPaymentLinkStatus(baseUrl, session.token, options.paymentLinkId);

--- a/src/commands/topup-crypto.ts
+++ b/src/commands/topup-crypto.ts
@@ -56,6 +56,19 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+export function validatePaymentPollingOptions(params: {
+  pollIntervalSeconds: number;
+  timeoutSeconds: number;
+}): void {
+  if (!Number.isFinite(params.pollIntervalSeconds) || params.pollIntervalSeconds <= 0) {
+    throw new CliError("Polling interval must be a positive number of seconds.");
+  }
+
+  if (!Number.isFinite(params.timeoutSeconds) || params.timeoutSeconds <= 0) {
+    throw new CliError("Timeout must be a positive number of seconds.");
+  }
+}
+
 export async function fetchPaymentLinkStatus(
   baseUrl: string,
   token: string,
@@ -116,6 +129,11 @@ export async function waitForPaymentLinkSettlement(params: {
   pollIntervalSeconds: number;
   timeoutSeconds: number;
 }): Promise<PaymentLinkRecord> {
+  validatePaymentPollingOptions({
+    pollIntervalSeconds: params.pollIntervalSeconds,
+    timeoutSeconds: params.timeoutSeconds,
+  });
+
   const startedAt = Date.now();
 
   while (true) {
@@ -150,6 +168,13 @@ export interface PaymentStatusOptions {
 export async function topupCrypto(options: TopupCryptoOptions): Promise<void> {
   if (!Number.isFinite(options.amount) || options.amount < 0.5) {
     throw new CliError("Amount must be >= 0.5 USD.");
+  }
+
+  if (options.wait) {
+    validatePaymentPollingOptions({
+      pollIntervalSeconds: options.pollIntervalSeconds,
+      timeoutSeconds: options.timeoutSeconds,
+    });
   }
 
   const session = await loadSession(options.sessionFile || DEFAULT_SESSION_FILE);
@@ -230,6 +255,13 @@ export async function topupCrypto(options: TopupCryptoOptions): Promise<void> {
 }
 
 export async function paymentStatus(options: PaymentStatusOptions): Promise<void> {
+  if (options.wait) {
+    validatePaymentPollingOptions({
+      pollIntervalSeconds: options.pollIntervalSeconds,
+      timeoutSeconds: options.timeoutSeconds,
+    });
+  }
+
   const session = await loadSession(options.sessionFile || DEFAULT_SESSION_FILE);
   const baseUrl = normalizeBaseUrl(options.baseUrl || session.baseUrl);
   const link = options.wait


### PR DESCRIPTION
## Summary
- validate `--poll-interval` and `--timeout` as finite positive numbers during CLI parsing
- add runtime guards in the payment polling helpers so invalid values are rejected even when the commands are called programmatically
- validate before side effects for `topup-crypto --wait` and `pay-payment-link --wait`

## Testing
- `npm run typecheck`
- `npm run build`
- `node dist/cli.js topup-crypto --base-url http://127.0.0.1:9 --amount 0.5 --wait --poll-interval 0 --timeout 10`
- `node dist/cli.js payment-status --base-url http://127.0.0.1:9 --payment-link-id dummy --wait --poll-interval NaN --timeout 10`
- `node dist/cli.js pay-payment-link --base-url http://127.0.0.1:9 --payment-link-id dummy --wait --poll-interval 5 --timeout -1`
- `node -e "import('./dist/commands/topup-crypto.js').then((m) => { try { m.validatePaymentPollingOptions({ pollIntervalSeconds: Number.NaN, timeoutSeconds: 10 }); process.exit(1); } catch (error) { const message = error instanceof Error ? error.message : String(error); console.log(message); process.exit(message === 'Polling interval must be a positive number of seconds.' ? 0 : 1); } })"`

Closes #13.
