### PR TITLE
fix(cloud-claw): block token forwarding to unsafe hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,8 @@ Inspect Cloud Claw user state:
 node dist/cli.js cloud-claw-me
 ```
 
+If you intentionally point Cloud Claw commands at a non-default host with `--cloud-claw-base-url`, also pass `--allow-cloud-claw-token-forwarding`. Without that explicit override, the CLI will refuse to POST your saved Portal session token to that host.
+
 List deployments:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Inspect Cloud Claw user state:
 node dist/cli.js cloud-claw-me
 ```
 
-If you intentionally point Cloud Claw commands at a non-default host with `--cloud-claw-base-url`, also pass `--allow-cloud-claw-token-forwarding`. Without that explicit override, the CLI will refuse to POST your saved Portal session token to that host.
+If you intentionally point Cloud Claw commands at a non-trusted host with `--cloud-claw-base-url`, also pass `--allow-cloud-claw-token-forwarding`. Without that explicit override, the CLI will refuse to POST your saved Portal session token to that host.
 
 List deployments:
 

--- a/skills/_shared/cloud-claw-preflight.md
+++ b/skills/_shared/cloud-claw-preflight.md
@@ -13,4 +13,4 @@ These notes apply when using the Cloud Claw skills from this repository.
    - VM lifecycle, renew, auto-renew, logs, and dashboard routes
 4. Assume Cloud Claw and AltLLM share session semantics. For scriptable user workflows, prefer `portal-sso` rather than re-describing the browser OAuth flow.
 5. Do not default to internal build/image scripts unless the user explicitly asks for infra maintenance.
-6. Do not forward the saved Portal session token to an arbitrary Cloud Claw host by default. If a non-default `--cloud-claw-base-url` is truly intended, require an explicit override such as `--allow-cloud-claw-token-forwarding`.
+6. Do not forward the saved Portal session token to an arbitrary Cloud Claw host by default. If a non-trusted `--cloud-claw-base-url` is truly intended, require an explicit override such as `--allow-cloud-claw-token-forwarding`.

--- a/skills/_shared/cloud-claw-preflight.md
+++ b/skills/_shared/cloud-claw-preflight.md
@@ -13,3 +13,4 @@ These notes apply when using the Cloud Claw skills from this repository.
    - VM lifecycle, renew, auto-renew, logs, and dashboard routes
 4. Assume Cloud Claw and AltLLM share session semantics. For scriptable user workflows, prefer `portal-sso` rather than re-describing the browser OAuth flow.
 5. Do not default to internal build/image scripts unless the user explicitly asks for infra maintenance.
+6. Do not forward the saved Portal session token to an arbitrary Cloud Claw host by default. If a non-default `--cloud-claw-base-url` is truly intended, require an explicit override such as `--allow-cloud-claw-token-forwarding`.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -35,6 +35,8 @@ import { DEFAULT_SESSION_FILE } from "./lib/session.js";
 const program = new Command();
 const DEFAULT_CLOUD_CLAW_BASE_URL =
   process.env.CLOUD_CLAW_BASE_URL || "https://claw.altllm.ai";
+const CLOUD_CLAW_TOKEN_FORWARDING_OPTION =
+  "Allow forwarding the saved Portal session token to a non-default Cloud Claw base URL";
 
 function collectOptionValues(value: string, previous?: string[]): string[] {
   return [...(previous ?? []), value];
@@ -87,11 +89,13 @@ program
   .option("--cloud-claw-base-url <url>", "Cloud Claw base URL", DEFAULT_CLOUD_CLAW_BASE_URL)
   .option("--session-file <path>", "Path to the saved Portal session", DEFAULT_SESSION_FILE)
   .option("--force-sso", "Force Cloud Claw to refresh portal-sso linkage", false)
+  .option("--allow-cloud-claw-token-forwarding", CLOUD_CLAW_TOKEN_FORWARDING_OPTION, false)
   .action(async (options) => {
     await cloudClawMe({
       baseUrl: options.cloudClawBaseUrl,
       sessionFile: options.sessionFile,
       forceSso: Boolean(options.forceSso),
+      allowTokenForwarding: Boolean(options.allowCloudClawTokenForwarding),
     });
   });
 
@@ -100,6 +104,7 @@ program
   .option("--cloud-claw-base-url <url>", "Cloud Claw base URL", DEFAULT_CLOUD_CLAW_BASE_URL)
   .option("--session-file <path>", "Path to the saved Portal session", DEFAULT_SESSION_FILE)
   .option("--force-sso", "Force Cloud Claw to refresh portal-sso linkage", false)
+  .option("--allow-cloud-claw-token-forwarding", CLOUD_CLAW_TOKEN_FORWARDING_OPTION, false)
   .option("--include-all", "List all deployments in admin mode", false)
   .option("--include-user-info", "Include user info when listing all deployments", false)
   .action(async (options) => {
@@ -107,6 +112,7 @@ program
       baseUrl: options.cloudClawBaseUrl,
       sessionFile: options.sessionFile,
       forceSso: Boolean(options.forceSso),
+      allowTokenForwarding: Boolean(options.allowCloudClawTokenForwarding),
       includeAll: Boolean(options.includeAll),
       includeUserInfo: Boolean(options.includeUserInfo),
     });
@@ -118,12 +124,14 @@ program
   .option("--cloud-claw-base-url <url>", "Cloud Claw base URL", DEFAULT_CLOUD_CLAW_BASE_URL)
   .option("--session-file <path>", "Path to the saved Portal session", DEFAULT_SESSION_FILE)
   .option("--force-sso", "Force Cloud Claw to refresh portal-sso linkage", false)
+  .option("--allow-cloud-claw-token-forwarding", CLOUD_CLAW_TOKEN_FORWARDING_OPTION, false)
   .action(async (options) => {
     await cloudClawDeployment({
       name: options.name,
       baseUrl: options.cloudClawBaseUrl,
       sessionFile: options.sessionFile,
       forceSso: Boolean(options.forceSso),
+      allowTokenForwarding: Boolean(options.allowCloudClawTokenForwarding),
     });
   });
 
@@ -140,6 +148,7 @@ program
   .option("--cloud-claw-base-url <url>", "Cloud Claw base URL", DEFAULT_CLOUD_CLAW_BASE_URL)
   .option("--session-file <path>", "Path to the saved Portal session", DEFAULT_SESSION_FILE)
   .option("--force-sso", "Force Cloud Claw to refresh portal-sso linkage", false)
+  .option("--allow-cloud-claw-token-forwarding", CLOUD_CLAW_TOKEN_FORWARDING_OPTION, false)
   .action(async (options) => {
     await cloudClawDeploy({
       name: options.name,
@@ -153,6 +162,7 @@ program
       baseUrl: options.cloudClawBaseUrl,
       sessionFile: options.sessionFile,
       forceSso: Boolean(options.forceSso),
+      allowTokenForwarding: Boolean(options.allowCloudClawTokenForwarding),
     });
   });
 
@@ -162,12 +172,14 @@ program
   .option("--cloud-claw-base-url <url>", "Cloud Claw base URL", DEFAULT_CLOUD_CLAW_BASE_URL)
   .option("--session-file <path>", "Path to the saved Portal session", DEFAULT_SESSION_FILE)
   .option("--force-sso", "Force Cloud Claw to refresh portal-sso linkage", false)
+  .option("--allow-cloud-claw-token-forwarding", CLOUD_CLAW_TOKEN_FORWARDING_OPTION, false)
   .action(async (options) => {
     await cloudClawStart({
       name: options.name,
       baseUrl: options.cloudClawBaseUrl,
       sessionFile: options.sessionFile,
       forceSso: Boolean(options.forceSso),
+      allowTokenForwarding: Boolean(options.allowCloudClawTokenForwarding),
     });
   });
 
@@ -177,12 +189,14 @@ program
   .option("--cloud-claw-base-url <url>", "Cloud Claw base URL", DEFAULT_CLOUD_CLAW_BASE_URL)
   .option("--session-file <path>", "Path to the saved Portal session", DEFAULT_SESSION_FILE)
   .option("--force-sso", "Force Cloud Claw to refresh portal-sso linkage", false)
+  .option("--allow-cloud-claw-token-forwarding", CLOUD_CLAW_TOKEN_FORWARDING_OPTION, false)
   .action(async (options) => {
     await cloudClawStop({
       name: options.name,
       baseUrl: options.cloudClawBaseUrl,
       sessionFile: options.sessionFile,
       forceSso: Boolean(options.forceSso),
+      allowTokenForwarding: Boolean(options.allowCloudClawTokenForwarding),
     });
   });
 
@@ -192,12 +206,14 @@ program
   .option("--cloud-claw-base-url <url>", "Cloud Claw base URL", DEFAULT_CLOUD_CLAW_BASE_URL)
   .option("--session-file <path>", "Path to the saved Portal session", DEFAULT_SESSION_FILE)
   .option("--force-sso", "Force Cloud Claw to refresh portal-sso linkage", false)
+  .option("--allow-cloud-claw-token-forwarding", CLOUD_CLAW_TOKEN_FORWARDING_OPTION, false)
   .action(async (options) => {
     await cloudClawRestart({
       name: options.name,
       baseUrl: options.cloudClawBaseUrl,
       sessionFile: options.sessionFile,
       forceSso: Boolean(options.forceSso),
+      allowTokenForwarding: Boolean(options.allowCloudClawTokenForwarding),
     });
   });
 
@@ -207,12 +223,14 @@ program
   .option("--cloud-claw-base-url <url>", "Cloud Claw base URL", DEFAULT_CLOUD_CLAW_BASE_URL)
   .option("--session-file <path>", "Path to the saved Portal session", DEFAULT_SESSION_FILE)
   .option("--force-sso", "Force Cloud Claw to refresh portal-sso linkage", false)
+  .option("--allow-cloud-claw-token-forwarding", CLOUD_CLAW_TOKEN_FORWARDING_OPTION, false)
   .action(async (options) => {
     await cloudClawRenew({
       name: options.name,
       baseUrl: options.cloudClawBaseUrl,
       sessionFile: options.sessionFile,
       forceSso: Boolean(options.forceSso),
+      allowTokenForwarding: Boolean(options.allowCloudClawTokenForwarding),
     });
   });
 
@@ -223,6 +241,7 @@ program
   .option("--cloud-claw-base-url <url>", "Cloud Claw base URL", DEFAULT_CLOUD_CLAW_BASE_URL)
   .option("--session-file <path>", "Path to the saved Portal session", DEFAULT_SESSION_FILE)
   .option("--force-sso", "Force Cloud Claw to refresh portal-sso linkage", false)
+  .option("--allow-cloud-claw-token-forwarding", CLOUD_CLAW_TOKEN_FORWARDING_OPTION, false)
   .action(async (options) => {
     await cloudClawAutoRenew({
       name: options.name,
@@ -230,6 +249,7 @@ program
       baseUrl: options.cloudClawBaseUrl,
       sessionFile: options.sessionFile,
       forceSso: Boolean(options.forceSso),
+      allowTokenForwarding: Boolean(options.allowCloudClawTokenForwarding),
     });
   });
 
@@ -239,12 +259,14 @@ program
   .option("--cloud-claw-base-url <url>", "Cloud Claw base URL", DEFAULT_CLOUD_CLAW_BASE_URL)
   .option("--session-file <path>", "Path to the saved Portal session", DEFAULT_SESSION_FILE)
   .option("--force-sso", "Force Cloud Claw to refresh portal-sso linkage", false)
+  .option("--allow-cloud-claw-token-forwarding", CLOUD_CLAW_TOKEN_FORWARDING_OPTION, false)
   .action(async (options) => {
     await cloudClawDelete({
       name: options.name,
       baseUrl: options.cloudClawBaseUrl,
       sessionFile: options.sessionFile,
       forceSso: Boolean(options.forceSso),
+      allowTokenForwarding: Boolean(options.allowCloudClawTokenForwarding),
     });
   });
 
@@ -254,6 +276,7 @@ program
   .option("--cloud-claw-base-url <url>", "Cloud Claw base URL", DEFAULT_CLOUD_CLAW_BASE_URL)
   .option("--session-file <path>", "Path to the saved Portal session", DEFAULT_SESSION_FILE)
   .option("--force-sso", "Force Cloud Claw to refresh portal-sso linkage", false)
+  .option("--allow-cloud-claw-token-forwarding", CLOUD_CLAW_TOKEN_FORWARDING_OPTION, false)
   .option("--stream", "Stream logs via SSE", false)
   .action(async (options) => {
     await cloudClawLogs({
@@ -261,6 +284,7 @@ program
       baseUrl: options.cloudClawBaseUrl,
       sessionFile: options.sessionFile,
       forceSso: Boolean(options.forceSso),
+      allowTokenForwarding: Boolean(options.allowCloudClawTokenForwarding),
       stream: Boolean(options.stream),
     });
   });

--- a/src/commands/cloud-claw-deploy.ts
+++ b/src/commands/cloud-claw-deploy.ts
@@ -20,6 +20,7 @@ export interface CloudClawDeployOptions {
   baseUrl?: string;
   sessionFile: string;
   forceSso?: boolean;
+  allowTokenForwarding?: boolean;
 }
 
 export async function cloudClawDeploy(
@@ -68,6 +69,7 @@ export async function cloudClawDeploy(
     baseUrl: options.baseUrl,
     sessionFile: options.sessionFile || DEFAULT_SESSION_FILE,
     forceSso: options.forceSso,
+    allowTokenForwarding: options.allowTokenForwarding,
   });
 
   writeJson(result);

--- a/src/commands/cloud-claw-deployment.ts
+++ b/src/commands/cloud-claw-deployment.ts
@@ -6,6 +6,7 @@ export interface CloudClawDeploymentOptions {
   baseUrl?: string;
   sessionFile: string;
   forceSso?: boolean;
+  allowTokenForwarding?: boolean;
 }
 
 export async function cloudClawDeployment(
@@ -17,6 +18,7 @@ export async function cloudClawDeployment(
     baseUrl: options.baseUrl,
     sessionFile: options.sessionFile || DEFAULT_SESSION_FILE,
     forceSso: options.forceSso,
+    allowTokenForwarding: options.allowTokenForwarding,
   });
 
   writeJson(result);

--- a/src/commands/cloud-claw-deployments.ts
+++ b/src/commands/cloud-claw-deployments.ts
@@ -7,6 +7,7 @@ export interface CloudClawDeploymentsOptions {
   includeAll?: boolean;
   includeUserInfo?: boolean;
   forceSso?: boolean;
+  allowTokenForwarding?: boolean;
 }
 
 export async function cloudClawDeployments(
@@ -27,6 +28,7 @@ export async function cloudClawDeployments(
     baseUrl: options.baseUrl,
     sessionFile: options.sessionFile || DEFAULT_SESSION_FILE,
     forceSso: options.forceSso,
+    allowTokenForwarding: options.allowTokenForwarding,
   });
 
   writeJson(result);

--- a/src/commands/cloud-claw-lifecycle.ts
+++ b/src/commands/cloud-claw-lifecycle.ts
@@ -6,6 +6,7 @@ export interface CloudClawLifecycleOptions {
   baseUrl?: string;
   sessionFile: string;
   forceSso?: boolean;
+  allowTokenForwarding?: boolean;
 }
 
 export interface CloudClawAutoRenewOptions extends CloudClawLifecycleOptions {
@@ -22,6 +23,7 @@ async function postLifecycle(
     baseUrl: options.baseUrl,
     sessionFile: options.sessionFile || DEFAULT_SESSION_FILE,
     forceSso: options.forceSso,
+    allowTokenForwarding: options.allowTokenForwarding,
   });
 
   writeJson(result);
@@ -46,6 +48,7 @@ export async function cloudClawDelete(options: CloudClawLifecycleOptions): Promi
     baseUrl: options.baseUrl,
     sessionFile: options.sessionFile || DEFAULT_SESSION_FILE,
     forceSso: options.forceSso,
+    allowTokenForwarding: options.allowTokenForwarding,
   });
 
   writeJson(result);
@@ -59,6 +62,7 @@ export async function cloudClawRestart(options: CloudClawLifecycleOptions): Prom
     baseUrl: options.baseUrl,
     sessionFile: options.sessionFile || DEFAULT_SESSION_FILE,
     forceSso: options.forceSso,
+    allowTokenForwarding: options.allowTokenForwarding,
   });
 
   const result = await requestCloudClawJson<Record<string, unknown>>({
@@ -67,6 +71,7 @@ export async function cloudClawRestart(options: CloudClawLifecycleOptions): Prom
     baseUrl: options.baseUrl,
     sessionFile: options.sessionFile || DEFAULT_SESSION_FILE,
     forceSso: options.forceSso,
+    allowTokenForwarding: options.allowTokenForwarding,
   });
 
   writeJson({
@@ -87,6 +92,7 @@ export async function cloudClawAutoRenew(
     baseUrl: options.baseUrl,
     sessionFile: options.sessionFile || DEFAULT_SESSION_FILE,
     forceSso: options.forceSso,
+    allowTokenForwarding: options.allowTokenForwarding,
   });
 
   writeJson(result);

--- a/src/commands/cloud-claw-logs.ts
+++ b/src/commands/cloud-claw-logs.ts
@@ -7,6 +7,7 @@ export interface CloudClawLogsOptions {
   baseUrl?: string;
   sessionFile: string;
   forceSso?: boolean;
+  allowTokenForwarding?: boolean;
   stream?: boolean;
 }
 
@@ -16,6 +17,7 @@ export async function cloudClawLogs(options: CloudClawLogsOptions): Promise<void
     baseUrl: options.baseUrl || DEFAULT_CLOUD_CLAW_BASE_URL,
     sessionFile: options.sessionFile || DEFAULT_SESSION_FILE,
     force: options.forceSso,
+    allowTokenForwarding: options.allowTokenForwarding,
   });
 
   if (!options.stream) {

--- a/src/commands/cloud-claw-me.ts
+++ b/src/commands/cloud-claw-me.ts
@@ -5,6 +5,7 @@ export interface CloudClawMeOptions {
   baseUrl?: string;
   sessionFile: string;
   forceSso?: boolean;
+  allowTokenForwarding?: boolean;
 }
 
 export async function cloudClawMe(options: CloudClawMeOptions): Promise<void> {
@@ -14,6 +15,7 @@ export async function cloudClawMe(options: CloudClawMeOptions): Promise<void> {
     baseUrl: options.baseUrl,
     sessionFile: options.sessionFile || DEFAULT_SESSION_FILE,
     forceSso: options.forceSso,
+    allowTokenForwarding: options.allowTokenForwarding,
   });
 
   writeJson(result);

--- a/src/lib/cloud-claw.ts
+++ b/src/lib/cloud-claw.ts
@@ -1,8 +1,9 @@
 import { CliError, normalizeBaseUrl, requestJson } from "./api.js";
 import { DEFAULT_SESSION_FILE, loadSession } from "./session.js";
 
+export const TRUSTED_CLOUD_CLAW_BASE_URL = "https://claw.altllm.ai";
 export const DEFAULT_CLOUD_CLAW_BASE_URL =
-  process.env.CLOUD_CLAW_BASE_URL || "https://claw.altllm.ai";
+  process.env.CLOUD_CLAW_BASE_URL || TRUSTED_CLOUD_CLAW_BASE_URL;
 
 export const CLOUD_CLAW_AGENT_TYPES = ["openclaw", "picoclaw", "aintern"] as const;
 export type CloudClawAgentType = (typeof CLOUD_CLAW_AGENT_TYPES)[number];
@@ -16,14 +17,16 @@ function ensureCloudClawBaseUrlAllowed(params: {
   allowTokenForwarding?: boolean;
 }): void {
   const normalizedBaseUrl = normalizeCloudClawBaseUrl(params.baseUrl);
-  const normalizedDefaultBaseUrl = normalizeCloudClawBaseUrl(DEFAULT_CLOUD_CLAW_BASE_URL);
+  const normalizedTrustedBaseUrl = normalizeCloudClawBaseUrl(
+    TRUSTED_CLOUD_CLAW_BASE_URL
+  );
 
   if (
-    normalizedBaseUrl !== normalizedDefaultBaseUrl &&
+    normalizedBaseUrl !== normalizedTrustedBaseUrl &&
     !params.allowTokenForwarding
   ) {
     throw new CliError(
-      `Refusing to forward the saved Portal session token to non-default Cloud Claw base URL ${normalizedBaseUrl}. Re-run with --allow-cloud-claw-token-forwarding if you trust this host.`
+      `Refusing to forward the saved Portal session token to non-trusted Cloud Claw base URL ${normalizedBaseUrl}. The trusted default is ${normalizedTrustedBaseUrl}. Re-run with --allow-cloud-claw-token-forwarding if you trust this host.`
     );
   }
 }

--- a/src/lib/cloud-claw.ts
+++ b/src/lib/cloud-claw.ts
@@ -11,15 +11,38 @@ function normalizeCloudClawBaseUrl(baseUrl: string): string {
   return normalizeBaseUrl(baseUrl);
 }
 
+function ensureCloudClawBaseUrlAllowed(params: {
+  baseUrl: string;
+  allowTokenForwarding?: boolean;
+}): void {
+  const normalizedBaseUrl = normalizeCloudClawBaseUrl(params.baseUrl);
+  const normalizedDefaultBaseUrl = normalizeCloudClawBaseUrl(DEFAULT_CLOUD_CLAW_BASE_URL);
+
+  if (
+    normalizedBaseUrl !== normalizedDefaultBaseUrl &&
+    !params.allowTokenForwarding
+  ) {
+    throw new CliError(
+      `Refusing to forward the saved Portal session token to non-default Cloud Claw base URL ${normalizedBaseUrl}. Re-run with --allow-cloud-claw-token-forwarding if you trust this host.`
+    );
+  }
+}
+
 export async function getCloudClawJwt(params: {
   baseUrl?: string;
   sessionFile: string;
   force?: boolean;
+  allowTokenForwarding?: boolean;
 }): Promise<{ baseUrl: string; jwt: string }> {
-  const session = await loadSession(params.sessionFile || DEFAULT_SESSION_FILE);
   const baseUrl = normalizeCloudClawBaseUrl(
     params.baseUrl || DEFAULT_CLOUD_CLAW_BASE_URL
   );
+  ensureCloudClawBaseUrlAllowed({
+    baseUrl,
+    allowTokenForwarding: params.allowTokenForwarding,
+  });
+
+  const session = await loadSession(params.sessionFile || DEFAULT_SESSION_FILE);
 
   const sso = await requestJson<{ authenticated?: boolean; token?: string }>({
     method: "POST",
@@ -44,11 +67,13 @@ export async function requestCloudClawJson<T>(params: {
   baseUrl?: string;
   sessionFile: string;
   forceSso?: boolean;
+  allowTokenForwarding?: boolean;
 }): Promise<T> {
   const { baseUrl, jwt } = await getCloudClawJwt({
     baseUrl: params.baseUrl,
     sessionFile: params.sessionFile,
     force: params.forceSso,
+    allowTokenForwarding: params.allowTokenForwarding,
   });
 
   return requestJson<T>({


### PR DESCRIPTION
## Summary
- block Cloud Claw commands from forwarding the saved Portal session token to a non-default `--cloud-claw-base-url` by default
- add an explicit `--allow-cloud-claw-token-forwarding` override for operators who intentionally trust a non-default host
- thread the override through all Cloud Claw CLI commands
- document the new safety rule in the README and shared Cloud Claw preflight notes

## Testing
- `npm run typecheck`
- `npm run build`
- `tmp=$(mktemp) && printf '{"baseUrl":"https://platform-api.altllm.ai","token":"fake-token","user":{"id":"u","email":"u@example.com"}}' > "$tmp" && node dist/cli.js cloud-claw-me --session-file "$tmp" --cloud-claw-base-url http://127.0.0.1:9`
- `tmp=$(mktemp) && printf '{"baseUrl":"https://platform-api.altllm.ai","token":"fake-token","user":{"id":"u","email":"u@example.com"}}' > "$tmp" && node dist/cli.js cloud-claw-me --session-file "$tmp" --cloud-claw-base-url http://127.0.0.1:9 --allow-cloud-claw-token-forwarding`

## Validation notes
- without the override flag, the CLI now refuses locally before loading or forwarding the saved Portal token
- with the override flag, the CLI proceeds to the target host as an explicit operator choice

Closes #21.
