### PR TITLE
fix(http): add timeouts for non-stream requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,6 +436,11 @@ node dist/cli.js pay-payment-link \
 - Terminal payment-link statuses such as `completed`, `expired`, `failed`, and `deactivated` are rejected before direct payment is sent.
 - Payment-link lookup currently scans the most recent `100` Portal payment links via `GET /api/billing/payment-links?limit=100`.
 
+## HTTP Timeouts
+
+- Non-stream CLI HTTP requests time out after `30000ms` by default.
+- Override this with `ALTLLM_HTTP_TIMEOUT_MS` if you need a different non-stream request timeout.
+
 Supported direct-payment currencies:
 
 - `eth`

--- a/src/commands/cloud-claw-logs.ts
+++ b/src/commands/cloud-claw-logs.ts
@@ -1,4 +1,4 @@
-import { CliError, normalizeBaseUrl } from "../lib/api.js";
+import { CliError, fetchWithTimeout, normalizeBaseUrl } from "../lib/api.js";
 import { DEFAULT_CLOUD_CLAW_BASE_URL, getCloudClawJwt, validateDeploymentName } from "../lib/cloud-claw.js";
 import { DEFAULT_SESSION_FILE } from "../lib/session.js";
 
@@ -19,7 +19,9 @@ export async function cloudClawLogs(options: CloudClawLogsOptions): Promise<void
   });
 
   if (!options.stream) {
-    const response = await fetch(`${normalizeBaseUrl(baseUrl)}/api/vm/deployments/${name}/logs`, {
+    const response = await fetchWithTimeout({
+      method: "GET",
+      url: `${normalizeBaseUrl(baseUrl)}/api/vm/deployments/${name}/logs`,
       headers: {
         Accept: "application/json",
         Authorization: `Bearer ${jwt}`,

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -5,8 +5,60 @@ export class CliError extends Error {
   }
 }
 
+const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
+
 export function normalizeBaseUrl(baseUrl: string): string {
   return baseUrl.replace(/\/+$/, "");
+}
+
+function resolveRequestTimeoutMs(): number {
+  const raw = process.env.ALTLLM_HTTP_TIMEOUT_MS?.trim();
+  if (!raw) {
+    return DEFAULT_REQUEST_TIMEOUT_MS;
+  }
+
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    throw new CliError("ALTLLM_HTTP_TIMEOUT_MS must be a positive number of milliseconds.");
+  }
+
+  return parsed;
+}
+
+export async function fetchWithTimeout(params: {
+  method: string;
+  url: string;
+  headers?: Record<string, string>;
+  body?: string;
+  timeoutMs?: number;
+}): Promise<Response> {
+  const timeoutMs = params.timeoutMs ?? resolveRequestTimeoutMs();
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    return await fetch(params.url, {
+      method: params.method,
+      headers: params.headers,
+      body: params.body,
+      signal: controller.signal,
+    });
+  } catch (error) {
+    if (
+      typeof error === "object" &&
+      error !== null &&
+      "name" in error &&
+      (error as { name?: string }).name === "AbortError"
+    ) {
+      throw new CliError(
+        `${params.method} ${params.url} timed out after ${timeoutMs}ms.`
+      );
+    }
+
+    throw error;
+  } finally {
+    clearTimeout(timer);
+  }
 }
 
 export async function requestJson<T>({
@@ -33,8 +85,9 @@ export async function requestJson<T>({
     headers.Authorization = `Bearer ${token}`;
   }
 
-  const response = await fetch(url, {
+  const response = await fetchWithTimeout({
     method,
+    url,
     headers,
     body: payload,
   });
@@ -48,4 +101,3 @@ export async function requestJson<T>({
 
   return json as T;
 }
-


### PR DESCRIPTION
## Summary
- add a default timeout for non-stream HTTP requests in `requestJson()`
- make the timeout configurable with `ALTLLM_HTTP_TIMEOUT_MS`
- return `CliError` with request context when non-stream requests time out
- apply the same timeout helper to the non-stream `cloud-claw-logs` path
- document the non-stream timeout behavior in the README

## Testing
- `npm run typecheck`
- `npm run build`
- start a local hang server that returns `/api/auth/portal-sso` immediately and never replies to other paths
- `tmp=$(mktemp) && printf '{"baseUrl":"http://127.0.0.1:18091","token":"fake-token","user":{"id":"u","email":"u@example.com"}}' > "$tmp" && ALTLLM_HTTP_TIMEOUT_MS=200 node dist/cli.js credit --session-file "$tmp"`
- `tmp=$(mktemp) && printf '{"baseUrl":"https://platform-api.altllm.ai","token":"fake-token","user":{"id":"u","email":"u@example.com"}}' > "$tmp" && ALTLLM_HTTP_TIMEOUT_MS=200 node dist/cli.js cloud-claw-logs --name test --session-file "$tmp" --cloud-claw-base-url http://127.0.0.1:18091`

Closes #22.
