### PR TITLE
fix(session): harden portal session file permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,8 @@ Successful login stores a session at:
 
 - `~/.altllm/portal-cli-session.json`
 
+On POSIX systems, the CLI saves the session directory and file with private permissions (`0700` for the directory and `0600` for the file).
+
 Remove the local Portal session:
 
 ```bash

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -1,4 +1,4 @@
-import { mkdir, readFile, unlink, writeFile } from "node:fs/promises";
+import { chmod, mkdir, readFile, unlink, writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
 import { homedir } from "node:os";
 
@@ -15,15 +15,44 @@ export interface PortalSession {
 }
 
 export const DEFAULT_SESSION_FILE = `${homedir()}/.altllm/portal-cli-session.json`;
+const SESSION_DIR_MODE = 0o700;
+const SESSION_FILE_MODE = 0o600;
+
+function isPermissionHardeningSupported(): boolean {
+  return process.platform !== "win32";
+}
+
+async function hardenSessionPathPermissions(path: string): Promise<void> {
+  if (!isPermissionHardeningSupported()) {
+    return;
+  }
+
+  await chmod(dirname(path), SESSION_DIR_MODE);
+  await chmod(path, SESSION_FILE_MODE);
+}
+
+async function tryHardenSessionPathPermissions(path: string): Promise<void> {
+  try {
+    await hardenSessionPathPermissions(path);
+  } catch {
+    // Best-effort on load: do not make a valid readable session unusable just
+    // because the host filesystem rejects chmod.
+  }
+}
 
 export async function saveSession(path: string, session: PortalSession): Promise<void> {
-  await mkdir(dirname(path), { recursive: true });
-  await writeFile(path, JSON.stringify(session, null, 2), "utf8");
+  await mkdir(dirname(path), { recursive: true, mode: SESSION_DIR_MODE });
+  await writeFile(path, JSON.stringify(session, null, 2), {
+    encoding: "utf8",
+    mode: SESSION_FILE_MODE,
+  });
+  await hardenSessionPathPermissions(path);
 }
 
 export async function loadSession(path: string): Promise<PortalSession> {
   try {
     const text = await readFile(path, "utf8");
+    await tryHardenSessionPathPermissions(path);
     return JSON.parse(text) as PortalSession;
   } catch (error) {
     throw new CliError(`Session file not found or invalid: ${path}. Run login-wallet first.`);

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -1,5 +1,5 @@
 import { chmod, mkdir, readFile, unlink, writeFile } from "node:fs/promises";
-import { dirname } from "node:path";
+import { dirname, resolve } from "node:path";
 import { homedir } from "node:os";
 
 import { CliError } from "./api.js";
@@ -17,6 +17,7 @@ export interface PortalSession {
 export const DEFAULT_SESSION_FILE = `${homedir()}/.altllm/portal-cli-session.json`;
 const SESSION_DIR_MODE = 0o700;
 const SESSION_FILE_MODE = 0o600;
+const DEFAULT_SESSION_DIRECTORY = dirname(DEFAULT_SESSION_FILE);
 
 function isPermissionHardeningSupported(): boolean {
   return process.platform !== "win32";
@@ -27,7 +28,9 @@ async function hardenSessionPathPermissions(path: string): Promise<void> {
     return;
   }
 
-  await chmod(dirname(path), SESSION_DIR_MODE);
+  if (resolve(dirname(path)) === resolve(DEFAULT_SESSION_DIRECTORY)) {
+    await chmod(dirname(path), SESSION_DIR_MODE);
+  }
   await chmod(path, SESSION_FILE_MODE);
 }
 
@@ -41,7 +44,13 @@ async function tryHardenSessionPathPermissions(path: string): Promise<void> {
 }
 
 export async function saveSession(path: string, session: PortalSession): Promise<void> {
-  await mkdir(dirname(path), { recursive: true, mode: SESSION_DIR_MODE });
+  const sessionDirectory = dirname(path);
+  const mkdirOptions =
+    resolve(sessionDirectory) === resolve(DEFAULT_SESSION_DIRECTORY)
+      ? { recursive: true, mode: SESSION_DIR_MODE }
+      : { recursive: true };
+
+  await mkdir(sessionDirectory, mkdirOptions);
   await writeFile(path, JSON.stringify(session, null, 2), {
     encoding: "utf8",
     mode: SESSION_FILE_MODE,


### PR DESCRIPTION
## Summary
- create the session directory with private permissions on POSIX systems
- write the Portal session file with private permissions on POSIX systems
- harden permissions after save so existing paths are corrected as well
- best-effort harden permissions when loading an existing session file
- document the private session permissions in the README

## Testing
- `npm run typecheck`
- `npm run build`
- `tmpdir=$(mktemp -d) && session_path="$tmpdir/.altllm/portal-cli-session.json" && node -e "import('./dist/lib/session.js').then(async (m) => { await m.saveSession(process.argv[1], { baseUrl: 'https://platform-api.altllm.ai', token: 'test-token', user: { id: 'u', email: 'u@example.com' } }); const loaded = await m.loadSession(process.argv[1]); console.log(JSON.stringify(loaded)); })" "$session_path" && printf 'dir=%s\nfile=%s\n' "$(stat -f %Lp "$tmpdir/.altllm")" "$(stat -f %Lp "$session_path")"`

## Verification
The manual permission check now reports:
- directory: `700`
- file: `600`

Closes #10.
