### PR TITLE
fix(cloud-claw): reject empty telegram allowlist input

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ For Telegram-backed deployments:
 
 - `--telegram-bot-token` is required for `picoclaw` and `aintern`
 - omitting `--telegram-allowed-users` on `picoclaw` or `aintern` allows everyone to message the bot
+- passing `--telegram-allowed-users ""` is rejected; use omission, not an empty string, for public bot behavior
 
 Manage an existing VM:
 

--- a/skills/cloud-claw-launch-agent/references/cli-reference.md
+++ b/skills/cloud-claw-launch-agent/references/cli-reference.md
@@ -40,6 +40,8 @@ node dist/cli.js cloud-claw-deploy \
   --telegram-allowed-users 123456789
 ```
 
+Omit `--telegram-allowed-users` only when you intentionally want a public bot. An explicitly empty value is rejected.
+
 ## Launch Ottie
 
 ```bash

--- a/src/lib/cloud-claw.ts
+++ b/src/lib/cloud-claw.ts
@@ -90,7 +90,9 @@ export function validateTelegramAllowedUsers(value?: string): string | undefined
 
   const trimmed = value.trim();
   if (!trimmed) {
-    return undefined;
+    throw new CliError(
+      "Telegram allowed users cannot be empty when provided. Omit --telegram-allowed-users to allow everyone."
+    );
   }
 
   if (!/^(\s*\d+\s*,)*\s*\d+\s*$/.test(trimmed)) {


### PR DESCRIPTION
## Summary
- reject an explicitly provided but empty `--telegram-allowed-users` value instead of treating it like omission
- preserve the existing omission behavior for intentionally public bots
- update the README and Cloud Claw launch reference to clarify that omission means public access, while an empty string is rejected

## Testing
- `npm run typecheck`
- `npm run build`
- `node dist/cli.js cloud-claw-deploy --name test-bot --agent-type picoclaw --telegram-bot-token dummy-token --telegram-allowed-users ""`

## Validation
- the command now fails locally with: `Telegram allowed users cannot be empty when provided. Omit --telegram-allowed-users to allow everyone.`
- during validation I accidentally hit the old built artifact once before the rebuild completed and created a real `test-bot` PicoClaw VM; I immediately issued `cloud-claw-delete --name test-bot` and confirmed cleanup with a follow-up `404 VM not found`

Closes #16.
