### PR TITLE
fix(portal): block token forwarding across base-url overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ Production default:
 
 Only use localhost when you are explicitly testing local Portal APIs.
 
+If a command is reusing your saved Portal session token, the CLI will refuse to send that token to a different `--base-url` host unless you also pass `--allow-token-host-mismatch`.
+
 ## Install
 
 ```bash

--- a/skills/_shared/preflight.md
+++ b/skills/_shared/preflight.md
@@ -15,3 +15,4 @@ Use these rules before the first `altllm` command in a fresh checkout or after c
 5. Treat `~/.altllm/portal-cli-session.json` as sensitive local state.
 6. Do not print private keys or full API keys except when the command intentionally returns a newly created key.
 7. If the task touches a live command, run a real check against the intended environment when practical.
+8. Do not forward a saved Portal session token to a different `--base-url` host by default. Require an explicit override such as `--allow-token-host-mismatch` when that mismatch is truly intended.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -38,6 +38,8 @@ const DEFAULT_CLOUD_CLAW_BASE_URL =
   process.env.CLOUD_CLAW_BASE_URL || "https://claw.altllm.ai";
 const CLOUD_CLAW_TOKEN_FORWARDING_OPTION =
   "Allow forwarding the saved Portal session token to a non-default Cloud Claw base URL";
+const PORTAL_TOKEN_HOST_MISMATCH_OPTION =
+  "Allow sending the saved Portal session token to a non-session --base-url";
 
 function collectOptionValues(value: string, previous?: string[]): string[] {
   return [...(previous ?? []), value];
@@ -312,10 +314,12 @@ program
   .command("credit")
   .option("--base-url <url>", "Portal API base URL")
   .option("--session-file <path>", "Path to the saved Portal session", DEFAULT_SESSION_FILE)
+  .option("--allow-token-host-mismatch", PORTAL_TOKEN_HOST_MISMATCH_OPTION, false)
   .action(async (options) => {
     await credit({
       baseUrl: options.baseUrl,
       sessionFile: options.sessionFile,
+      allowTokenHostMismatch: Boolean(options.allowTokenHostMismatch),
     });
   });
 
@@ -323,6 +327,7 @@ program
   .command("transactions")
   .option("--base-url <url>", "Portal API base URL")
   .option("--session-file <path>", "Path to the saved Portal session", DEFAULT_SESSION_FILE)
+  .option("--allow-token-host-mismatch", PORTAL_TOKEN_HOST_MISMATCH_OPTION, false)
   .option("--page <number>", "Page number (1-indexed)")
   .option("--limit <number>", "Items per page (1-100)")
   .option("--type <type>", "Transaction type filter: all, credit, usage, or refund")
@@ -330,6 +335,7 @@ program
     await transactions({
       baseUrl: options.baseUrl,
       sessionFile: options.sessionFile,
+      allowTokenHostMismatch: Boolean(options.allowTokenHostMismatch),
       page: options.page === undefined ? undefined : Number(options.page),
       limit: options.limit === undefined ? undefined : Number(options.limit),
       type: options.type,
@@ -340,10 +346,12 @@ program
   .command("usage-summary")
   .option("--base-url <url>", "Portal API base URL")
   .option("--session-file <path>", "Path to the saved Portal session", DEFAULT_SESSION_FILE)
+  .option("--allow-token-host-mismatch", PORTAL_TOKEN_HOST_MISMATCH_OPTION, false)
   .action(async (options) => {
     await usageSummary({
       baseUrl: options.baseUrl,
       sessionFile: options.sessionFile,
+      allowTokenHostMismatch: Boolean(options.allowTokenHostMismatch),
     });
   });
 
@@ -351,6 +359,7 @@ program
   .command("usage-timeline")
   .option("--base-url <url>", "Portal API base URL")
   .option("--session-file <path>", "Path to the saved Portal session", DEFAULT_SESSION_FILE)
+  .option("--allow-token-host-mismatch", PORTAL_TOKEN_HOST_MISMATCH_OPTION, false)
   .option("--month <yyyy-mm>", "Month filter in YYYY-MM format")
   .option("--start-date <yyyy-mm-dd>", "Start date in YYYY-MM-DD format")
   .option("--end-date <yyyy-mm-dd>", "End date in YYYY-MM-DD format")
@@ -358,6 +367,7 @@ program
     await usageTimeline({
       baseUrl: options.baseUrl,
       sessionFile: options.sessionFile,
+      allowTokenHostMismatch: Boolean(options.allowTokenHostMismatch),
       month: options.month,
       startDate: options.startDate,
       endDate: options.endDate,
@@ -368,6 +378,7 @@ program
   .command("usage-by-model")
   .option("--base-url <url>", "Portal API base URL")
   .option("--session-file <path>", "Path to the saved Portal session", DEFAULT_SESSION_FILE)
+  .option("--allow-token-host-mismatch", PORTAL_TOKEN_HOST_MISMATCH_OPTION, false)
   .option("--month <yyyy-mm>", "Month filter in YYYY-MM format")
   .option("--start-date <yyyy-mm-dd>", "Start date in YYYY-MM-DD format")
   .option("--end-date <yyyy-mm-dd>", "End date in YYYY-MM-DD format")
@@ -375,6 +386,7 @@ program
     await usageByModel({
       baseUrl: options.baseUrl,
       sessionFile: options.sessionFile,
+      allowTokenHostMismatch: Boolean(options.allowTokenHostMismatch),
       month: options.month,
       startDate: options.startDate,
       endDate: options.endDate,
@@ -385,12 +397,14 @@ program
   .command("usage-by-key")
   .option("--base-url <url>", "Portal API base URL")
   .option("--session-file <path>", "Path to the saved Portal session", DEFAULT_SESSION_FILE)
+  .option("--allow-token-host-mismatch", PORTAL_TOKEN_HOST_MISMATCH_OPTION, false)
   .option("--start-date <yyyy-mm-dd>", "Start date in YYYY-MM-DD format")
   .option("--end-date <yyyy-mm-dd>", "End date in YYYY-MM-DD format")
   .action(async (options) => {
     await usageByKey({
       baseUrl: options.baseUrl,
       sessionFile: options.sessionFile,
+      allowTokenHostMismatch: Boolean(options.allowTokenHostMismatch),
       startDate: options.startDate,
       endDate: options.endDate,
     });
@@ -400,10 +414,12 @@ program
   .command("list-api-keys")
   .option("--base-url <url>", "Portal API base URL")
   .option("--session-file <path>", "Path to the saved Portal session", DEFAULT_SESSION_FILE)
+  .option("--allow-token-host-mismatch", PORTAL_TOKEN_HOST_MISMATCH_OPTION, false)
   .action(async (options) => {
     await listApiKeys({
       baseUrl: options.baseUrl,
       sessionFile: options.sessionFile,
+      allowTokenHostMismatch: Boolean(options.allowTokenHostMismatch),
     });
   });
 
@@ -414,6 +430,7 @@ program
   .option("--models <ids>", "Comma-separated allowed model IDs")
   .option("--base-url <url>", "Portal API base URL")
   .option("--session-file <path>", "Path to the saved Portal session", DEFAULT_SESSION_FILE)
+  .option("--allow-token-host-mismatch", PORTAL_TOKEN_HOST_MISMATCH_OPTION, false)
   .action(async (options) => {
     await createApiKey({
       name: options.name,
@@ -421,6 +438,7 @@ program
       models: options.models,
       baseUrl: options.baseUrl,
       sessionFile: options.sessionFile,
+      allowTokenHostMismatch: Boolean(options.allowTokenHostMismatch),
     });
   });
 
@@ -429,11 +447,13 @@ program
   .requiredOption("--key-id <id>", "API key ID")
   .option("--base-url <url>", "Portal API base URL")
   .option("--session-file <path>", "Path to the saved Portal session", DEFAULT_SESSION_FILE)
+  .option("--allow-token-host-mismatch", PORTAL_TOKEN_HOST_MISMATCH_OPTION, false)
   .action(async (options) => {
     await getApiKey({
       keyId: options.keyId,
       baseUrl: options.baseUrl,
       sessionFile: options.sessionFile,
+      allowTokenHostMismatch: Boolean(options.allowTokenHostMismatch),
     });
   });
 
@@ -446,6 +466,7 @@ program
   .option("--models <ids>", "Comma-separated allowed model IDs")
   .option("--base-url <url>", "Portal API base URL")
   .option("--session-file <path>", "Path to the saved Portal session", DEFAULT_SESSION_FILE)
+  .option("--allow-token-host-mismatch", PORTAL_TOKEN_HOST_MISMATCH_OPTION, false)
   .action(async (options) => {
     await updateApiKey({
       keyId: options.keyId,
@@ -455,6 +476,7 @@ program
       models: options.models,
       baseUrl: options.baseUrl,
       sessionFile: options.sessionFile,
+      allowTokenHostMismatch: Boolean(options.allowTokenHostMismatch),
     });
   });
 
@@ -463,11 +485,13 @@ program
   .requiredOption("--key-id <id>", "API key ID")
   .option("--base-url <url>", "Portal API base URL")
   .option("--session-file <path>", "Path to the saved Portal session", DEFAULT_SESSION_FILE)
+  .option("--allow-token-host-mismatch", PORTAL_TOKEN_HOST_MISMATCH_OPTION, false)
   .action(async (options) => {
     await revokeApiKey({
       keyId: options.keyId,
       baseUrl: options.baseUrl,
       sessionFile: options.sessionFile,
+      allowTokenHostMismatch: Boolean(options.allowTokenHostMismatch),
     });
   });
 
@@ -476,11 +500,13 @@ program
   .requiredOption("--code <code>", "Promo code to redeem")
   .option("--base-url <url>", "Portal API base URL")
   .option("--session-file <path>", "Path to the saved Portal session", DEFAULT_SESSION_FILE)
+  .option("--allow-token-host-mismatch", PORTAL_TOKEN_HOST_MISMATCH_OPTION, false)
   .action(async (options) => {
     await redeemPromo({
       code: options.code,
       baseUrl: options.baseUrl,
       sessionFile: options.sessionFile,
+      allowTokenHostMismatch: Boolean(options.allowTokenHostMismatch),
     });
   });
 
@@ -494,6 +520,7 @@ program
   .option("--private-key-env <name>", "Environment variable containing the private key", "ALTLLM_WALLET_PRIVATE_KEY")
   .option("--redirect-url <url>", "Optional redirect URL after payment")
   .option("--session-file <path>", "Path to the saved Portal session", DEFAULT_SESSION_FILE)
+  .option("--allow-token-host-mismatch", PORTAL_TOKEN_HOST_MISMATCH_OPTION, false)
   .option("--wait", "Poll until the payment reaches a terminal state", false)
   .option("--poll-interval <seconds>", "Polling interval in seconds", "10")
   .option("--timeout <seconds>", "Maximum wait time in seconds", "600")
@@ -507,6 +534,7 @@ program
       privateKeyEnv: options.privateKeyEnv,
       redirectUrl: options.redirectUrl,
       sessionFile: options.sessionFile,
+      allowTokenHostMismatch: Boolean(options.allowTokenHostMismatch),
       wait: Boolean(options.wait),
       pollIntervalSeconds: parsePositiveNumberOption(
         options.pollInterval,
@@ -521,6 +549,7 @@ program
   .requiredOption("--payment-link-id <id>", "Payment link ID")
   .option("--base-url <url>", "Portal API base URL")
   .option("--session-file <path>", "Path to the saved Portal session", DEFAULT_SESSION_FILE)
+  .option("--allow-token-host-mismatch", PORTAL_TOKEN_HOST_MISMATCH_OPTION, false)
   .option("--wait", "Poll until the payment reaches a terminal state", false)
   .option("--poll-interval <seconds>", "Polling interval in seconds", "10")
   .option("--timeout <seconds>", "Maximum wait time in seconds", "600")
@@ -529,6 +558,7 @@ program
       paymentLinkId: options.paymentLinkId,
       baseUrl: options.baseUrl,
       sessionFile: options.sessionFile,
+      allowTokenHostMismatch: Boolean(options.allowTokenHostMismatch),
       wait: Boolean(options.wait),
       pollIntervalSeconds: parsePositiveNumberOption(
         options.pollInterval,
@@ -543,6 +573,7 @@ program
   .requiredOption("--payment-link-id <id>", "Payment link ID")
   .option("--base-url <url>", "Portal API base URL")
   .option("--session-file <path>", "Path to the saved Portal session", DEFAULT_SESSION_FILE)
+  .option("--allow-token-host-mismatch", PORTAL_TOKEN_HOST_MISMATCH_OPTION, false)
   .option("--private-key <hex>", "EVM private key for automatic payment")
   .option("--private-key-env <name>", "Environment variable containing the private key", "ALTLLM_WALLET_PRIVATE_KEY")
   .option("--wait", "Poll until the payment reaches a terminal state after broadcast", false)
@@ -553,6 +584,7 @@ program
       paymentLinkId: options.paymentLinkId,
       baseUrl: options.baseUrl,
       sessionFile: options.sessionFile,
+      allowTokenHostMismatch: Boolean(options.allowTokenHostMismatch),
       privateKey: options.privateKey,
       privateKeyEnv: options.privateKeyEnv,
       wait: Boolean(options.wait),

--- a/src/commands/create-api-key.ts
+++ b/src/commands/create-api-key.ts
@@ -14,6 +14,7 @@ export interface CreateApiKeyOptions {
   model?: string[];
   baseUrl?: string;
   sessionFile: string;
+  allowTokenHostMismatch?: boolean;
 }
 
 export async function createApiKey(options: CreateApiKeyOptions): Promise<void> {
@@ -26,6 +27,7 @@ export async function createApiKey(options: CreateApiKeyOptions): Promise<void> 
   const { baseUrl, token } = await resolvePortalContext({
     baseUrl: options.baseUrl,
     sessionFile: options.sessionFile || DEFAULT_SESSION_FILE,
+    allowTokenHostMismatch: options.allowTokenHostMismatch,
   });
 
   const result = await requestJson<CreateKeyResponse>({

--- a/src/commands/credit.ts
+++ b/src/commands/credit.ts
@@ -1,14 +1,25 @@
 import { normalizeBaseUrl, requestJson } from "../lib/api.js";
-import { DEFAULT_SESSION_FILE, loadSession } from "../lib/session.js";
+import {
+  DEFAULT_SESSION_FILE,
+  loadSession,
+  resolveSessionBackedBaseUrl,
+} from "../lib/session.js";
 
 export interface CreditOptions {
   baseUrl?: string;
   sessionFile: string;
+  allowTokenHostMismatch?: boolean;
 }
 
 export async function credit(options: CreditOptions): Promise<void> {
   const session = await loadSession(options.sessionFile || DEFAULT_SESSION_FILE);
-  const baseUrl = normalizeBaseUrl(options.baseUrl || session.baseUrl);
+  const baseUrl = normalizeBaseUrl(
+    resolveSessionBackedBaseUrl({
+      sessionBaseUrl: session.baseUrl,
+      baseUrl: options.baseUrl,
+      allowTokenHostMismatch: options.allowTokenHostMismatch,
+    })
+  );
 
   const result = await requestJson<Record<string, unknown>>({
     method: "GET",
@@ -18,4 +29,3 @@ export async function credit(options: CreditOptions): Promise<void> {
 
   process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
 }
-

--- a/src/commands/get-api-key.ts
+++ b/src/commands/get-api-key.ts
@@ -6,12 +6,14 @@ export interface GetApiKeyOptions {
   keyId: string;
   baseUrl?: string;
   sessionFile: string;
+  allowTokenHostMismatch?: boolean;
 }
 
 export async function getApiKey(options: GetApiKeyOptions): Promise<void> {
   const { baseUrl, token } = await resolvePortalContext({
     baseUrl: options.baseUrl,
     sessionFile: options.sessionFile || DEFAULT_SESSION_FILE,
+    allowTokenHostMismatch: options.allowTokenHostMismatch,
   });
 
   const result = await requestJson<KeyDetail>({

--- a/src/commands/list-api-keys.ts
+++ b/src/commands/list-api-keys.ts
@@ -5,12 +5,14 @@ import { DEFAULT_SESSION_FILE } from "../lib/session.js";
 export interface ListApiKeysOptions {
   baseUrl?: string;
   sessionFile: string;
+  allowTokenHostMismatch?: boolean;
 }
 
 export async function listApiKeys(options: ListApiKeysOptions): Promise<void> {
   const { baseUrl, token } = await resolvePortalContext({
     baseUrl: options.baseUrl,
     sessionFile: options.sessionFile || DEFAULT_SESSION_FILE,
+    allowTokenHostMismatch: options.allowTokenHostMismatch,
   });
 
   const result = await requestJson<ListKeysResponse>({

--- a/src/commands/pay-payment-link.ts
+++ b/src/commands/pay-payment-link.ts
@@ -1,5 +1,9 @@
 import { CliError, normalizeBaseUrl } from "../lib/api.js";
-import { DEFAULT_SESSION_FILE, loadSession } from "../lib/session.js";
+import {
+  DEFAULT_SESSION_FILE,
+  loadSession,
+  resolveSessionBackedBaseUrl,
+} from "../lib/session.js";
 import { executeDirectPayment, resolvePrivateKey } from "../lib/wallet.js";
 import {
   fetchPaymentLinkStatus,
@@ -18,6 +22,7 @@ export interface PayPaymentLinkOptions {
   wait?: boolean;
   pollIntervalSeconds: number;
   timeoutSeconds: number;
+  allowTokenHostMismatch?: boolean;
 }
 
 export async function payPaymentLink(options: PayPaymentLinkOptions): Promise<void> {
@@ -29,7 +34,13 @@ export async function payPaymentLink(options: PayPaymentLinkOptions): Promise<vo
   }
 
   const session = await loadSession(options.sessionFile || DEFAULT_SESSION_FILE);
-  const baseUrl = normalizeBaseUrl(options.baseUrl || session.baseUrl);
+  const baseUrl = normalizeBaseUrl(
+    resolveSessionBackedBaseUrl({
+      sessionBaseUrl: session.baseUrl,
+      baseUrl: options.baseUrl,
+      allowTokenHostMismatch: options.allowTokenHostMismatch,
+    })
+  );
   const link = await fetchPaymentLinkStatus(baseUrl, session.token, options.paymentLinkId);
 
   if (isTerminalPaymentLinkStatus(link.status)) {

--- a/src/commands/redeem-promo.ts
+++ b/src/commands/redeem-promo.ts
@@ -1,15 +1,26 @@
 import { normalizeBaseUrl, requestJson } from "../lib/api.js";
-import { DEFAULT_SESSION_FILE, loadSession } from "../lib/session.js";
+import {
+  DEFAULT_SESSION_FILE,
+  loadSession,
+  resolveSessionBackedBaseUrl,
+} from "../lib/session.js";
 
 export interface RedeemPromoOptions {
   code: string;
   baseUrl?: string;
   sessionFile: string;
+  allowTokenHostMismatch?: boolean;
 }
 
 export async function redeemPromo(options: RedeemPromoOptions): Promise<void> {
   const session = await loadSession(options.sessionFile || DEFAULT_SESSION_FILE);
-  const baseUrl = normalizeBaseUrl(options.baseUrl || session.baseUrl);
+  const baseUrl = normalizeBaseUrl(
+    resolveSessionBackedBaseUrl({
+      sessionBaseUrl: session.baseUrl,
+      baseUrl: options.baseUrl,
+      allowTokenHostMismatch: options.allowTokenHostMismatch,
+    })
+  );
 
   const result = await requestJson<Record<string, unknown>>({
     method: "POST",

--- a/src/commands/revoke-api-key.ts
+++ b/src/commands/revoke-api-key.ts
@@ -10,12 +10,14 @@ export interface RevokeApiKeyOptions {
   keyId: string;
   baseUrl?: string;
   sessionFile: string;
+  allowTokenHostMismatch?: boolean;
 }
 
 export async function revokeApiKey(options: RevokeApiKeyOptions): Promise<void> {
   const { baseUrl, token } = await resolvePortalContext({
     baseUrl: options.baseUrl,
     sessionFile: options.sessionFile || DEFAULT_SESSION_FILE,
+    allowTokenHostMismatch: options.allowTokenHostMismatch,
   });
 
   const result = await requestJson<KeyDeletedResponse>({

--- a/src/commands/topup-crypto.ts
+++ b/src/commands/topup-crypto.ts
@@ -1,5 +1,9 @@
 import { CliError, normalizeBaseUrl, requestJson } from "../lib/api.js";
-import { DEFAULT_SESSION_FILE, loadSession } from "../lib/session.js";
+import {
+  DEFAULT_SESSION_FILE,
+  loadSession,
+  resolveSessionBackedBaseUrl,
+} from "../lib/session.js";
 import { executeDirectPayment, resolvePrivateKey } from "../lib/wallet.js";
 
 export interface TopupCryptoOptions {
@@ -14,6 +18,7 @@ export interface TopupCryptoOptions {
   wait?: boolean;
   pollIntervalSeconds: number;
   timeoutSeconds: number;
+  allowTokenHostMismatch?: boolean;
 }
 
 interface CreatePaymentLinkResponse {
@@ -163,6 +168,7 @@ export interface PaymentStatusOptions {
   wait?: boolean;
   pollIntervalSeconds: number;
   timeoutSeconds: number;
+  allowTokenHostMismatch?: boolean;
 }
 
 export async function topupCrypto(options: TopupCryptoOptions): Promise<void> {
@@ -178,7 +184,13 @@ export async function topupCrypto(options: TopupCryptoOptions): Promise<void> {
   }
 
   const session = await loadSession(options.sessionFile || DEFAULT_SESSION_FILE);
-  const baseUrl = normalizeBaseUrl(options.baseUrl || session.baseUrl);
+  const baseUrl = normalizeBaseUrl(
+    resolveSessionBackedBaseUrl({
+      sessionBaseUrl: session.baseUrl,
+      baseUrl: options.baseUrl,
+      allowTokenHostMismatch: options.allowTokenHostMismatch,
+    })
+  );
 
   const created = await requestJson<CreatePaymentLinkResponse>({
     method: "POST",
@@ -263,7 +275,13 @@ export async function paymentStatus(options: PaymentStatusOptions): Promise<void
   }
 
   const session = await loadSession(options.sessionFile || DEFAULT_SESSION_FILE);
-  const baseUrl = normalizeBaseUrl(options.baseUrl || session.baseUrl);
+  const baseUrl = normalizeBaseUrl(
+    resolveSessionBackedBaseUrl({
+      sessionBaseUrl: session.baseUrl,
+      baseUrl: options.baseUrl,
+      allowTokenHostMismatch: options.allowTokenHostMismatch,
+    })
+  );
   const link = options.wait
     ? await waitForPaymentLinkSettlement({
         baseUrl,

--- a/src/commands/transactions.ts
+++ b/src/commands/transactions.ts
@@ -12,12 +12,14 @@ export interface TransactionsOptions {
   page?: number;
   limit?: number;
   type?: string;
+  allowTokenHostMismatch?: boolean;
 }
 
 export async function transactions(options: TransactionsOptions): Promise<void> {
   const { baseUrl, token } = await resolvePortalContext({
     baseUrl: options.baseUrl,
     sessionFile: options.sessionFile || DEFAULT_SESSION_FILE,
+    allowTokenHostMismatch: options.allowTokenHostMismatch,
   });
 
   const searchParams = new URLSearchParams();

--- a/src/commands/update-api-key.ts
+++ b/src/commands/update-api-key.ts
@@ -17,6 +17,7 @@ export interface UpdateApiKeyOptions {
   model?: string[];
   baseUrl?: string;
   sessionFile: string;
+  allowTokenHostMismatch?: boolean;
 }
 
 export async function updateApiKey(options: UpdateApiKeyOptions): Promise<void> {
@@ -51,6 +52,7 @@ export async function updateApiKey(options: UpdateApiKeyOptions): Promise<void> 
   const { baseUrl, token } = await resolvePortalContext({
     baseUrl: options.baseUrl,
     sessionFile: options.sessionFile || DEFAULT_SESSION_FILE,
+    allowTokenHostMismatch: options.allowTokenHostMismatch,
   });
 
   const result = await requestJson<KeyDetail>({

--- a/src/commands/usage-by-key.ts
+++ b/src/commands/usage-by-key.ts
@@ -8,12 +8,14 @@ export interface UsageByKeyOptions {
   sessionFile: string;
   startDate?: string;
   endDate?: string;
+  allowTokenHostMismatch?: boolean;
 }
 
 export async function usageByKey(options: UsageByKeyOptions): Promise<void> {
   const { baseUrl, token } = await resolvePortalContext({
     baseUrl: options.baseUrl,
     sessionFile: options.sessionFile || DEFAULT_SESSION_FILE,
+    allowTokenHostMismatch: options.allowTokenHostMismatch,
   });
 
   const searchParams = new URLSearchParams();

--- a/src/commands/usage-by-model.ts
+++ b/src/commands/usage-by-model.ts
@@ -9,12 +9,14 @@ export interface UsageByModelOptions {
   startDate?: string;
   endDate?: string;
   month?: string;
+  allowTokenHostMismatch?: boolean;
 }
 
 export async function usageByModel(options: UsageByModelOptions): Promise<void> {
   const { baseUrl, token } = await resolvePortalContext({
     baseUrl: options.baseUrl,
     sessionFile: options.sessionFile || DEFAULT_SESSION_FILE,
+    allowTokenHostMismatch: options.allowTokenHostMismatch,
   });
 
   const searchParams = new URLSearchParams();

--- a/src/commands/usage-summary.ts
+++ b/src/commands/usage-summary.ts
@@ -5,12 +5,14 @@ import { DEFAULT_SESSION_FILE } from "../lib/session.js";
 export interface UsageSummaryOptions {
   baseUrl?: string;
   sessionFile: string;
+  allowTokenHostMismatch?: boolean;
 }
 
 export async function usageSummary(options: UsageSummaryOptions): Promise<void> {
   const { baseUrl, token } = await resolvePortalContext({
     baseUrl: options.baseUrl,
     sessionFile: options.sessionFile || DEFAULT_SESSION_FILE,
+    allowTokenHostMismatch: options.allowTokenHostMismatch,
   });
 
   const result = await requestJson<Record<string, unknown>>({

--- a/src/commands/usage-timeline.ts
+++ b/src/commands/usage-timeline.ts
@@ -9,12 +9,14 @@ export interface UsageTimelineOptions {
   startDate?: string;
   endDate?: string;
   month?: string;
+  allowTokenHostMismatch?: boolean;
 }
 
 export async function usageTimeline(options: UsageTimelineOptions): Promise<void> {
   const { baseUrl, token } = await resolvePortalContext({
     baseUrl: options.baseUrl,
     sessionFile: options.sessionFile || DEFAULT_SESSION_FILE,
+    allowTokenHostMismatch: options.allowTokenHostMismatch,
   });
 
   const searchParams = new URLSearchParams();

--- a/src/lib/keys.ts
+++ b/src/lib/keys.ts
@@ -1,5 +1,9 @@
 import { CliError, normalizeBaseUrl } from "./api.js";
-import { DEFAULT_SESSION_FILE, loadSession } from "./session.js";
+import {
+  DEFAULT_SESSION_FILE,
+  loadSession,
+  resolveSessionBackedBaseUrl,
+} from "./session.js";
 
 export interface KeyPermissions {
   models: string[];
@@ -51,10 +55,17 @@ const API_KEY_NAME_MAX_LENGTH = 64;
 export async function resolvePortalContext(options: {
   baseUrl?: string;
   sessionFile: string;
+  allowTokenHostMismatch?: boolean;
 }): Promise<{ baseUrl: string; token: string }> {
   const session = await loadSession(options.sessionFile || DEFAULT_SESSION_FILE);
   return {
-    baseUrl: normalizeBaseUrl(options.baseUrl || session.baseUrl),
+    baseUrl: normalizeBaseUrl(
+      resolveSessionBackedBaseUrl({
+        sessionBaseUrl: session.baseUrl,
+        baseUrl: options.baseUrl,
+        allowTokenHostMismatch: options.allowTokenHostMismatch,
+      })
+    ),
     token: session.token,
   };
 }

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -2,7 +2,7 @@ import { mkdir, readFile, unlink, writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
 import { homedir } from "node:os";
 
-import { CliError } from "./api.js";
+import { CliError, normalizeBaseUrl } from "./api.js";
 
 export interface PortalSession {
   baseUrl: string;
@@ -15,6 +15,28 @@ export interface PortalSession {
 }
 
 export const DEFAULT_SESSION_FILE = `${homedir()}/.altllm/portal-cli-session.json`;
+
+export function resolveSessionBackedBaseUrl(params: {
+  sessionBaseUrl: string;
+  baseUrl?: string;
+  allowTokenHostMismatch?: boolean;
+}): string {
+  const normalizedSessionBaseUrl = normalizeBaseUrl(params.sessionBaseUrl);
+  const normalizedBaseUrl = normalizeBaseUrl(
+    params.baseUrl || params.sessionBaseUrl
+  );
+
+  if (
+    normalizedBaseUrl !== normalizedSessionBaseUrl &&
+    !params.allowTokenHostMismatch
+  ) {
+    throw new CliError(
+      `Refusing to send the saved Portal session token to non-session base URL ${normalizedBaseUrl}. Session origin is ${normalizedSessionBaseUrl}. Re-run with --allow-token-host-mismatch if you trust this host.`
+    );
+  }
+
+  return normalizedBaseUrl;
+}
 
 export async function saveSession(path: string, session: PortalSession): Promise<void> {
   await mkdir(dirname(path), { recursive: true });


### PR DESCRIPTION
## Summary
- block saved Portal session tokens from being sent to a different `--base-url` host by default
- add an explicit `--allow-token-host-mismatch` escape hatch for intentional cross-host use
- apply the guard across all session-backed Portal commands, not just one or two billing paths
- document the new safety rule in the README and shared preflight notes

## Testing
- `npm run typecheck`
- `npm run build`
- `tmp=$(mktemp) && printf '{"baseUrl":"https://platform-api.altllm.ai","token":"FAKE_PORTAL_TOKEN","user":{"id":"u","email":"u@example.com"}}' > "$tmp" && node dist/cli.js credit --session-file "$tmp" --base-url http://127.0.0.1:9`
- `tmp=$(mktemp) && printf '{"baseUrl":"https://platform-api.altllm.ai","token":"FAKE_PORTAL_TOKEN","user":{"id":"u","email":"u@example.com"}}' > "$tmp" && node dist/cli.js credit --session-file "$tmp" --base-url http://127.0.0.1:9 --allow-token-host-mismatch`
- `tmp=$(mktemp) && printf '{"baseUrl":"https://platform-api.altllm.ai","token":"FAKE_PORTAL_TOKEN","user":{"id":"u","email":"u@example.com"}}' > "$tmp" && node dist/cli.js list-api-keys --session-file "$tmp" --base-url http://127.0.0.1:9`
- `tmp=$(mktemp) && printf '{"baseUrl":"https://platform-api.altllm.ai","token":"FAKE_PORTAL_TOKEN","user":{"id":"u","email":"u@example.com"}}' > "$tmp" && node dist/cli.js list-api-keys --session-file "$tmp" --base-url http://127.0.0.1:9 --allow-token-host-mismatch`

## Validation notes
- without the override flag, the CLI now refuses locally before sending the saved token
- with the override flag, the CLI proceeds to the operator-selected host as an explicit choice

Closes #20.
