### PR TITLE
fix(cloud-claw): validate auto-renew enabled flag

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -61,6 +61,18 @@ function parsePositiveNumberOption(value: string, optionName: string): number {
   return parsed;
 }
 
+function parseBooleanOption(value: string, optionName: string): boolean {
+  const normalized = value.trim().toLowerCase();
+  if (normalized === "true") {
+    return true;
+  }
+  if (normalized === "false") {
+    return false;
+  }
+
+  throw new CliError(`${optionName} must be either true or false.`);
+}
+
 program
   .name("altllm")
   .description("CLI for AltLLM Portal auth, API key management, billing, and payments");
@@ -264,7 +276,7 @@ program
   .action(async (options) => {
     await cloudClawAutoRenew({
       name: options.name,
-      enabled: String(options.enabled).toLowerCase() === "true",
+      enabled: parseBooleanOption(options.enabled, "--enabled"),
       baseUrl: options.cloudClawBaseUrl,
       sessionFile: options.sessionFile,
       forceSso: Boolean(options.forceSso),


### PR DESCRIPTION
## Summary
- validate `cloud-claw-auto-renew --enabled` instead of silently coercing unknown values to `false`
- accept only explicit `true` or `false`
- fail fast locally with a clear `CliError` for invalid inputs such as `tru` or `yes`

## Testing
- `npm run typecheck`
- `npm run build`
- `node dist/cli.js cloud-claw-auto-renew --name demo --enabled tru`
- `node dist/cli.js cloud-claw-auto-renew --name demo --enabled yes`
- `tmp=$(mktemp) && printf '{"baseUrl":"https://platform-api.altllm.ai","token":"fake-token","user":{"id":"u","email":"u@example.com"}}' > "$tmp" && node dist/cli.js cloud-claw-auto-renew --name demo --enabled false --session-file "$tmp" --cloud-claw-base-url http://127.0.0.1:9 --allow-cloud-claw-token-forwarding`

Closes #15.
