### PR TITLE
docs(cloud-claw): replace sibling repo file links

### DIFF
--- a/skills/cloud-claw/references/skill-map.md
+++ b/skills/cloud-claw/references/skill-map.md
@@ -7,13 +7,13 @@
 | `cloud-claw-launch-agent` | `cloud-claw-deploy`, `cloud-claw-me` | wraps deployment form semantics and pre-launch checks |
 | `cloud-claw-manage-vm` | `cloud-claw-deployments`, `cloud-claw-deployment`, `cloud-claw-start`, `cloud-claw-stop`, `cloud-claw-restart`, `cloud-claw-renew`, `cloud-claw-auto-renew`, `cloud-claw-delete`, `cloud-claw-logs` | wraps the user-facing Cloud Claw API |
 
-## Source Files In The Sibling Repo
+## Source Files In The Cloud Claw Repo
 
-- [../cloud-claw/AGENTS.md](../../../../cloud-claw/AGENTS.md)
-- [../cloud-claw/README.md](../../../../cloud-claw/README.md)
-- [../cloud-claw/server/src/routes/auth.ts](../../../../cloud-claw/server/src/routes/auth.ts)
-- [../cloud-claw/server/src/routes/vm-deployment.ts](../../../../cloud-claw/server/src/routes/vm-deployment.ts)
-- [../cloud-claw/server/src/services/vm.ts](../../../../cloud-claw/server/src/services/vm.ts)
-- [../cloud-claw/server/src/services/altllm.ts](../../../../cloud-claw/server/src/services/altllm.ts)
-- [../cloud-claw/server/src/services/user-store.ts](../../../../cloud-claw/server/src/services/user-store.ts)
-- [../cloud-claw/web/src/App.tsx](../../../../cloud-claw/web/src/App.tsx)
+- [cloud-claw/AGENTS.md](https://github.com/alt-research/cloud-claw/blob/main/AGENTS.md)
+- [cloud-claw/README.md](https://github.com/alt-research/cloud-claw/blob/main/README.md)
+- [cloud-claw/server/src/routes/auth.ts](https://github.com/alt-research/cloud-claw/blob/main/server/src/routes/auth.ts)
+- [cloud-claw/server/src/routes/vm-deployment.ts](https://github.com/alt-research/cloud-claw/blob/main/server/src/routes/vm-deployment.ts)
+- [cloud-claw/server/src/services/vm.ts](https://github.com/alt-research/cloud-claw/blob/main/server/src/services/vm.ts)
+- [cloud-claw/server/src/services/altllm.ts](https://github.com/alt-research/cloud-claw/blob/main/server/src/services/altllm.ts)
+- [cloud-claw/server/src/services/user-store.ts](https://github.com/alt-research/cloud-claw/blob/main/server/src/services/user-store.ts)
+- [cloud-claw/web/src/App.tsx](https://github.com/alt-research/cloud-claw/blob/main/web/src/App.tsx)

--- a/skills/cloud-claw/references/skill-map.md
+++ b/skills/cloud-claw/references/skill-map.md
@@ -9,11 +9,11 @@
 
 ## Source Files In The Cloud Claw Repo
 
-- [cloud-claw/AGENTS.md](https://github.com/alt-research/cloud-claw/blob/main/AGENTS.md)
-- [cloud-claw/README.md](https://github.com/alt-research/cloud-claw/blob/main/README.md)
-- [cloud-claw/server/src/routes/auth.ts](https://github.com/alt-research/cloud-claw/blob/main/server/src/routes/auth.ts)
-- [cloud-claw/server/src/routes/vm-deployment.ts](https://github.com/alt-research/cloud-claw/blob/main/server/src/routes/vm-deployment.ts)
-- [cloud-claw/server/src/services/vm.ts](https://github.com/alt-research/cloud-claw/blob/main/server/src/services/vm.ts)
-- [cloud-claw/server/src/services/altllm.ts](https://github.com/alt-research/cloud-claw/blob/main/server/src/services/altllm.ts)
-- [cloud-claw/server/src/services/user-store.ts](https://github.com/alt-research/cloud-claw/blob/main/server/src/services/user-store.ts)
-- [cloud-claw/web/src/App.tsx](https://github.com/alt-research/cloud-claw/blob/main/web/src/App.tsx)
+- [cloud-claw/AGENTS.md](https://github.com/alt-research/cloud-claw/blob/master/AGENTS.md)
+- [cloud-claw/README.md](https://github.com/alt-research/cloud-claw/blob/master/README.md)
+- [cloud-claw/server/src/routes/auth.ts](https://github.com/alt-research/cloud-claw/blob/master/server/src/routes/auth.ts)
+- [cloud-claw/server/src/routes/vm-deployment.ts](https://github.com/alt-research/cloud-claw/blob/master/server/src/routes/vm-deployment.ts)
+- [cloud-claw/server/src/services/vm.ts](https://github.com/alt-research/cloud-claw/blob/master/server/src/services/vm.ts)
+- [cloud-claw/server/src/services/altllm.ts](https://github.com/alt-research/cloud-claw/blob/master/server/src/services/altllm.ts)
+- [cloud-claw/server/src/services/portal-store.ts](https://github.com/alt-research/cloud-claw/blob/master/server/src/services/portal-store.ts)
+- [cloud-claw/web/src/App.tsx](https://github.com/alt-research/cloud-claw/blob/master/web/src/App.tsx)


### PR DESCRIPTION
## Summary
- replace sibling-checkout filesystem-relative links in the Cloud Claw skill map with stable GitHub links to the `alt-research/cloud-claw` repository
- keep the reference list useful in standalone clones and in GitHub UI views of this repository

## Testing
- visually verified that the old `../../../../cloud-claw/...` links were replaced with `https://github.com/alt-research/cloud-claw/blob/main/...` links

Closes #19.
