### PR TITLE
fix(api): preserve context for non-json error bodies

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -9,18 +9,6 @@ export function normalizeBaseUrl(baseUrl: string): string {
   return baseUrl.replace(/\/+$/, "");
 }
 
-function tryParseJson(text: string): unknown {
-  if (!text) {
-    return {};
-  }
-
-  try {
-    return JSON.parse(text);
-  } catch {
-    return undefined;
-  }
-}
-
 export async function requestJson<T>({
   method,
   url,
@@ -57,10 +45,13 @@ export async function requestJson<T>({
     throw new CliError(`${method} ${url} failed: ${response.status} ${text}`);
   }
 
-  const json = tryParseJson(text);
-  if (text && json === undefined) {
-    throw new CliError(`${method} ${url} returned invalid JSON: ${text}`);
+  if (!text) {
+    return {} as T;
   }
 
-  return (json ?? {}) as T;
+  try {
+    return JSON.parse(text) as T;
+  } catch {
+    throw new CliError(`${method} ${url} returned invalid JSON: ${text}`);
+  }
 }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -9,6 +9,18 @@ export function normalizeBaseUrl(baseUrl: string): string {
   return baseUrl.replace(/\/+$/, "");
 }
 
+function tryParseJson(text: string): unknown {
+  if (!text) {
+    return {};
+  }
+
+  try {
+    return JSON.parse(text);
+  } catch {
+    return undefined;
+  }
+}
+
 export async function requestJson<T>({
   method,
   url,
@@ -40,12 +52,15 @@ export async function requestJson<T>({
   });
 
   const text = await response.text();
-  const json = text ? JSON.parse(text) : {};
 
   if (!response.ok) {
     throw new CliError(`${method} ${url} failed: ${response.status} ${text}`);
   }
 
-  return json as T;
-}
+  const json = tryParseJson(text);
+  if (text && json === undefined) {
+    throw new CliError(`${method} ${url} returned invalid JSON: ${text}`);
+  }
 
+  return (json ?? {}) as T;
+}


### PR DESCRIPTION
## Summary
- stop unconditionally JSON-parsing response bodies before checking `response.ok`
- preserve HTTP method, URL, status, and raw error text when the server returns a non-JSON error body
- return a clear `CliError` for successful responses that still contain invalid JSON instead of throwing a bare `SyntaxError`

## Testing
- `npm run typecheck`
- `npm run build`
- start a local test server that returns `502 text/plain` on `/error` and `200 text/plain` on `/ok-text`
- `node -e "import('./dist/lib/api.js').then(async (m) => { try { await m.requestJson({ method: 'GET', url: 'http://127.0.0.1:18092/error' }); process.exit(1); } catch (error) { const message = error instanceof Error ? error.message : String(error); console.log(message); process.exit(message === 'GET http://127.0.0.1:18092/error failed: 502 upstream bad gateway' ? 0 : 1); } })"`
- `node -e "import('./dist/lib/api.js').then(async (m) => { try { await m.requestJson({ method: 'GET', url: 'http://127.0.0.1:18092/ok-text' }); process.exit(1); } catch (error) { const message = error instanceof Error ? error.message : String(error); console.log(message); process.exit(message === 'GET http://127.0.0.1:18092/ok-text returned invalid JSON: not-json-success' ? 0 : 1); } })"`

Closes #14.
