### PR TITLE
fix(cloud-claw): add non-argv secret inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Launch a new PicoClaw:
 node dist/cli.js cloud-claw-deploy \
   --name swift-owl-9 \
   --agent-type picoclaw \
-  --telegram-bot-token 123456789:ABC... \
+  --telegram-bot-token-env TELEGRAM_BOT_TOKEN \
   --telegram-allowed-users 123456789
 ```
 
@@ -153,14 +153,20 @@ node dist/cli.js cloud-claw-deploy \
   --name happy-fox-12 \
   --agent-type openclaw \
   --model altllm/altllm-standard \
-  --telegram-bot-token 123456789:ABC... \
+  --telegram-bot-token-env TELEGRAM_BOT_TOKEN \
   --telegram-allowed-users 123456789
 ```
 
 For Telegram-backed deployments:
 
 - `--telegram-bot-token` is required for `picoclaw` and `aintern`
+- safer alternatives are `--telegram-bot-token-env` and `--telegram-bot-token-file`
 - omitting `--telegram-allowed-users` on `picoclaw` or `aintern` allows everyone to message the bot
+
+Other deployment secrets also support non-argv input:
+
+- `--altllm-api-key-env` / `--altllm-api-key-file`
+- `--anthropic-api-key-env` / `--anthropic-api-key-file`
 
 Manage an existing VM:
 

--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ node dist/cli.js cloud-claw-deployment --name swift-owl-9
 Launch a new PicoClaw:
 
 ```bash
+export TELEGRAM_BOT_TOKEN=123456:ABC-your-telegram-bot-token
 node dist/cli.js cloud-claw-deploy \
   --name swift-owl-9 \
   --agent-type picoclaw \
@@ -149,6 +150,7 @@ node dist/cli.js cloud-claw-deploy \
 Launch a new OpenClaw:
 
 ```bash
+export TELEGRAM_BOT_TOKEN=123456:ABC-your-telegram-bot-token
 node dist/cli.js cloud-claw-deploy \
   --name happy-fox-12 \
   --agent-type openclaw \

--- a/skills/cloud-claw-launch-agent/references/cli-reference.md
+++ b/skills/cloud-claw-launch-agent/references/cli-reference.md
@@ -22,33 +22,49 @@ Important fields:
 ## Launch OpenClaw
 
 ```bash
+TELEGRAM_BOT_TOKEN=123456789:ABC... \
 node dist/cli.js cloud-claw-deploy \
   --name happy-fox-12 \
   --agent-type openclaw \
   --model altllm/altllm-standard \
-  --telegram-bot-token 123456789:ABC... \
+  --telegram-bot-token-env TELEGRAM_BOT_TOKEN \
   --telegram-allowed-users 123456789
 ```
 
 ## Launch PicoClaw
 
 ```bash
+TELEGRAM_BOT_TOKEN=123456789:ABC... \
 node dist/cli.js cloud-claw-deploy \
   --name swift-panda-58 \
   --agent-type picoclaw \
-  --telegram-bot-token 123456789:ABC... \
+  --telegram-bot-token-env TELEGRAM_BOT_TOKEN \
   --telegram-allowed-users 123456789
 ```
 
 ## Launch Ottie
 
 ```bash
+TELEGRAM_BOT_TOKEN=123456789:ABC... \
 node dist/cli.js cloud-claw-deploy \
   --name brave-owl-14 \
   --agent-type aintern \
-  --telegram-bot-token 123456789:ABC... \
+  --telegram-bot-token-env TELEGRAM_BOT_TOKEN \
   --telegram-allowed-users 123456789
 ```
+
+## Secret Input Options
+
+For deployment secrets, the CLI supports:
+
+- direct flags such as `--telegram-bot-token`
+- environment-variable selectors such as `--telegram-bot-token-env TELEGRAM_BOT_TOKEN`
+- file selectors such as `--telegram-bot-token-file /path/to/token.txt`
+
+The same pattern also applies to:
+
+- `--altllm-api-key`
+- `--anthropic-api-key`
 
 ## Representative success response
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -133,10 +133,16 @@ program
   .requiredOption("--agent-type <type>", "Agent type: openclaw, picoclaw, or aintern")
   .option("--model <model>", "OpenClaw model, for example altllm/altllm-standard")
   .option("--telegram-bot-token <token>", "Telegram bot token for PicoClaw or Ottie")
+  .option("--telegram-bot-token-env <name>", "Environment variable containing the Telegram bot token")
+  .option("--telegram-bot-token-file <path>", "File containing the Telegram bot token")
   .option("--telegram-allowed-users <ids>", "Comma-separated numeric Telegram user IDs")
   .option("--altllm-api-key <key>", "Optional explicit AltLLM API key override")
+  .option("--altllm-api-key-env <name>", "Environment variable containing the AltLLM API key override")
+  .option("--altllm-api-key-file <path>", "File containing the AltLLM API key override")
   .option("--altllm-api-base <url>", "Optional explicit AltLLM API base override")
   .option("--anthropic-api-key <key>", "Optional Anthropic API key override")
+  .option("--anthropic-api-key-env <name>", "Environment variable containing the Anthropic API key")
+  .option("--anthropic-api-key-file <path>", "File containing the Anthropic API key")
   .option("--cloud-claw-base-url <url>", "Cloud Claw base URL", DEFAULT_CLOUD_CLAW_BASE_URL)
   .option("--session-file <path>", "Path to the saved Portal session", DEFAULT_SESSION_FILE)
   .option("--force-sso", "Force Cloud Claw to refresh portal-sso linkage", false)
@@ -146,10 +152,16 @@ program
       agentType: options.agentType,
       model: options.model,
       telegramBotToken: options.telegramBotToken,
+      telegramBotTokenEnv: options.telegramBotTokenEnv,
+      telegramBotTokenFile: options.telegramBotTokenFile,
       telegramAllowedUsers: options.telegramAllowedUsers,
       altllmApiKey: options.altllmApiKey,
+      altllmApiKeyEnv: options.altllmApiKeyEnv,
+      altllmApiKeyFile: options.altllmApiKeyFile,
       altllmApiBase: options.altllmApiBase,
       anthropicApiKey: options.anthropicApiKey,
+      anthropicApiKeyEnv: options.anthropicApiKeyEnv,
+      anthropicApiKeyFile: options.anthropicApiKeyFile,
       baseUrl: options.cloudClawBaseUrl,
       sessionFile: options.sessionFile,
       forceSso: Boolean(options.forceSso),

--- a/src/commands/cloud-claw-deploy.ts
+++ b/src/commands/cloud-claw-deploy.ts
@@ -1,4 +1,5 @@
 import { CliError } from "../lib/api.js";
+import { readFile } from "node:fs/promises";
 import {
   parseCloudClawAgentType,
   requestCloudClawJson,
@@ -13,13 +14,74 @@ export interface CloudClawDeployOptions {
   agentType: string;
   model?: string;
   telegramBotToken?: string;
+  telegramBotTokenEnv?: string;
+  telegramBotTokenFile?: string;
   telegramAllowedUsers?: string;
   altllmApiKey?: string;
+  altllmApiKeyEnv?: string;
+  altllmApiKeyFile?: string;
   altllmApiBase?: string;
   anthropicApiKey?: string;
+  anthropicApiKeyEnv?: string;
+  anthropicApiKeyFile?: string;
   baseUrl?: string;
   sessionFile: string;
   forceSso?: boolean;
+}
+
+async function resolveOptionalSecret(params: {
+  label: string;
+  direct?: string;
+  envName?: string;
+  filePath?: string;
+}): Promise<string | undefined> {
+  const configuredSources = [
+    params.direct !== undefined ? "direct" : undefined,
+    params.envName !== undefined ? "env" : undefined,
+    params.filePath !== undefined ? "file" : undefined,
+  ].filter((value): value is string => value !== undefined);
+
+  if (configuredSources.length > 1) {
+    throw new CliError(
+      `Provide ${params.label} via only one source: direct flag, --${params.label}-env, or --${params.label}-file.`
+    );
+  }
+
+  if (params.direct !== undefined) {
+    const trimmed = params.direct.trim();
+    if (!trimmed) {
+      throw new CliError(`${params.label} cannot be empty when provided.`);
+    }
+    return trimmed;
+  }
+
+  if (params.envName !== undefined) {
+    const envName = params.envName.trim();
+    if (!envName) {
+      throw new CliError(`--${params.label}-env cannot be empty.`);
+    }
+
+    const value = process.env[envName]?.trim();
+    if (!value) {
+      throw new CliError(`Environment variable ${envName} is missing or empty.`);
+    }
+    return value;
+  }
+
+  if (params.filePath !== undefined) {
+    const filePath = params.filePath.trim();
+    if (!filePath) {
+      throw new CliError(`--${params.label}-file cannot be empty.`);
+    }
+
+    const value = (await readFile(filePath, "utf8")).trim();
+    if (!value) {
+      throw new CliError(`Secret file is empty: ${filePath}`);
+    }
+    return value;
+  }
+
+  return undefined;
 }
 
 export async function cloudClawDeploy(
@@ -27,8 +89,26 @@ export async function cloudClawDeploy(
 ): Promise<void> {
   const name = validateDeploymentName(options.name);
   const agentType = parseCloudClawAgentType(options.agentType);
+  const telegramBotToken = await resolveOptionalSecret({
+    label: "telegram-bot-token",
+    direct: options.telegramBotToken,
+    envName: options.telegramBotTokenEnv,
+    filePath: options.telegramBotTokenFile,
+  });
+  const altllmApiKey = await resolveOptionalSecret({
+    label: "altllm-api-key",
+    direct: options.altllmApiKey,
+    envName: options.altllmApiKeyEnv,
+    filePath: options.altllmApiKeyFile,
+  });
+  const anthropicApiKey = await resolveOptionalSecret({
+    label: "anthropic-api-key",
+    direct: options.anthropicApiKey,
+    envName: options.anthropicApiKeyEnv,
+    filePath: options.anthropicApiKeyFile,
+  });
 
-  if ((agentType === "picoclaw" || agentType === "aintern") && !options.telegramBotToken?.trim()) {
+  if ((agentType === "picoclaw" || agentType === "aintern") && !telegramBotToken) {
     throw new CliError("Telegram bot token is required for picoclaw and aintern deployments.");
   }
 
@@ -40,21 +120,21 @@ export async function cloudClawDeploy(
   if (agentType === "openclaw" && options.model?.trim()) {
     env.OPENCLAW_MODEL = options.model.trim();
   }
-  if (options.telegramBotToken?.trim()) {
-    env.TELEGRAM_BOT_TOKEN = options.telegramBotToken.trim();
+  if (telegramBotToken) {
+    env.TELEGRAM_BOT_TOKEN = telegramBotToken;
   }
   const allowedUsers = validateTelegramAllowedUsers(options.telegramAllowedUsers);
   if (allowedUsers) {
     env.TELEGRAM_ALLOWED_USERS = allowedUsers;
   }
-  if (options.altllmApiKey?.trim()) {
-    env.ALTLLM_API_KEY = options.altllmApiKey.trim();
+  if (altllmApiKey) {
+    env.ALTLLM_API_KEY = altllmApiKey;
   }
   if (options.altllmApiBase?.trim()) {
     env.ALTLLM_API_BASE = options.altllmApiBase.trim();
   }
-  if (options.anthropicApiKey?.trim()) {
-    env.ANTHROPIC_API_KEY = options.anthropicApiKey.trim();
+  if (anthropicApiKey) {
+    env.ANTHROPIC_API_KEY = anthropicApiKey;
   }
 
   const result = await requestCloudClawJson<Record<string, unknown>>({


### PR DESCRIPTION
## Summary
- add non-argv secret input paths for Cloud Claw deployment secrets
- support `--*-env <ENV_NAME>` and `--*-file <path>` for:
  - `telegram-bot-token`
  - `altllm-api-key`
  - `anthropic-api-key`
- reject ambiguous multi-source secret input instead of silently picking one
- document the safer input paths in the README and Cloud Claw launch reference

## Testing
- `npm run typecheck`
- `npm run build`
- `TELEGRAM_BOT_TOKEN=dummy-token node dist/cli.js cloud-claw-deploy --name demo-bot --agent-type picoclaw --telegram-bot-token-env TELEGRAM_BOT_TOKEN --session-file "$tmp"`
- `token_file=$(mktemp) && printf 'dummy-token\n' > "$token_file" && node dist/cli.js cloud-claw-deploy --name demo-bot --agent-type picoclaw --telegram-bot-token-file "$token_file" --session-file "$tmp"`
- `TELEGRAM_BOT_TOKEN=dummy-token node dist/cli.js cloud-claw-deploy --name demo-bot --agent-type picoclaw --telegram-bot-token direct-token --telegram-bot-token-env TELEGRAM_BOT_TOKEN`

## Validation notes
- env and file secret sources both resolved successfully and reached the network layer
- mixed secret sources now fail locally with a clear validation error

Closes #11.
