### PR TITLE
docs(package): point metadata URLs to altllm-skills

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,14 +9,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/alt-research/altllm-cli.git"
+    "url": "git+https://github.com/alt-research/altllm-skills.git"
   },
   "license": "ISC",
   "type": "module",
   "bugs": {
-    "url": "https://github.com/alt-research/altllm-cli/issues"
+    "url": "https://github.com/alt-research/altllm-skills/issues"
   },
-  "homepage": "https://github.com/alt-research/altllm-cli#readme",
+  "homepage": "https://github.com/alt-research/altllm-skills#readme",
   "bin": {
     "altllm": "dist/cli.js"
   },


### PR DESCRIPTION
## Summary
- update `package.json` metadata URLs to point to `alt-research/altllm-skills`
- fix `repository.url`, `bugs.url`, and `homepage` so packaging metadata matches the current repository

## Testing
- verified the three metadata fields in `package.json` now reference `alt-research/altllm-skills`

Closes #23.
