### PR TITLE
docs(api-keys): note known production route breakage

### DIFF
--- a/skills/altllm-portal-api-keys/SKILL.md
+++ b/skills/altllm-portal-api-keys/SKILL.md
@@ -32,6 +32,17 @@ Portal API key lifecycle management for the local `altllm` CLI.
 - `update-api-key --status disabled` is reversible.
 - `revoke-api-key` is permanent.
 
+## Known Production Limitation
+
+- The single-key Portal API routes are currently broken in production.
+- Affected commands:
+  - `get-api-key`
+  - `update-api-key`
+  - `revoke-api-key`
+- Commands that still work:
+  - `list-api-keys`
+  - `create-api-key`
+
 ## Reference
 
 See [references/cli-reference.md](references/cli-reference.md) for command examples and representative responses.

--- a/skills/altllm-portal-api-keys/references/cli-reference.md
+++ b/skills/altllm-portal-api-keys/references/cli-reference.md
@@ -38,6 +38,11 @@ node dist/cli.js get-api-key \
   --key-id <id>
 ```
 
+Known production limitation:
+
+- The current production Portal backend rejects valid key IDs on single-key routes.
+- Expect `get-api-key`, `update-api-key`, and `revoke-api-key` to fail until the backend issue is fixed.
+
 ### Update key
 
 ```bash
@@ -60,4 +65,4 @@ node dist/cli.js revoke-api-key \
 ## Notes
 
 - Keys created through Portal are for the AltLLM OpenAI-compatible gateway at `https://api.altllm.ai/v1`.
-- `get-api-key` depends on the corresponding Portal API endpoint being healthy.
+- `get-api-key`, `update-api-key`, and `revoke-api-key` are currently blocked by a known production backend issue on the single-key Portal routes.


### PR DESCRIPTION
## Summary
- document the known production breakage of single-key Portal API routes directly in the focused API-key skill docs
- align the focused API-key skill with the broader guide so operators are not sent into a known broken workflow

## Testing
- reviewed `GUIDE.md`, `skills/altllm-portal-api-keys/SKILL.md`, and `skills/altllm-portal-api-keys/references/cli-reference.md` together to confirm the limitation messaging is now consistent

Closes #18.
