### PR TITLE
fix(cloud-claw): pass token forwarding through restart poll

### DIFF
--- a/src/commands/cloud-claw-lifecycle.ts
+++ b/src/commands/cloud-claw-lifecycle.ts
@@ -56,6 +56,7 @@ async function fetchDeploymentStatus(
     baseUrl: options.baseUrl,
     sessionFile: options.sessionFile || DEFAULT_SESSION_FILE,
     forceSso: options.forceSso,
+    allowTokenForwarding: options.allowTokenForwarding,
   });
 
   const status = result.deployment?.status?.trim().toLowerCase();


### PR DESCRIPTION
## Summary
- thread `allowTokenForwarding` through the deployment-status poll used by `cloud-claw-restart`
- keep the host-allowance decision consistent across the full restart flow: stop, poll, and start

## Testing
- `npm run typecheck`
- `npm run build`
- start a local mock Cloud Claw server that:
  - returns a JWT from `/api/auth/portal-sso`
  - accepts `POST /api/vm/deployments/demo/stop`
  - returns `stopping` then `terminated` from `GET /api/vm/deployments/demo`
  - accepts `POST /api/vm/deployments/demo/start`
- `tmp=$(mktemp) && printf '{"baseUrl":"https://platform-api.altllm.ai","token":"fake-token","user":{"id":"u","email":"u@example.com"}}' > "$tmp" && node dist/cli.js cloud-claw-restart --name demo --session-file "$tmp" --cloud-claw-base-url http://127.0.0.1:18093 --allow-cloud-claw-token-forwarding`

## Validation
The restart flow now completes successfully under the explicit non-default-host override and returns:
- `stopResult`
- `restartReadyStatus: "terminated"`
- `startResult`

Closes #38.
