### PR TITLE
fix(billing): enforce usage filter contracts

### DIFF
--- a/skills/altllm-portal-billing/SKILL.md
+++ b/skills/altllm-portal-billing/SKILL.md
@@ -32,8 +32,8 @@ Balance, promo, transaction history, and usage analytics for the local `altllm` 
 - History commands mostly return raw Portal API JSON.
 - `transactions` supports `--page`, `--limit`, and `--type`.
 - `usage-summary` currently reflects the current calendar month only.
-- `usage-timeline` and `usage-by-model` support either `--month` or an explicit date range.
-- `usage-by-key` currently supports explicit date range only.
+- `usage-timeline` and `usage-by-model` support either `--month` or a complete explicit date range.
+- `usage-by-key` currently requires a complete explicit date range.
 
 ## Reference
 

--- a/skills/altllm-portal-billing/references/cli-reference.md
+++ b/skills/altllm-portal-billing/references/cli-reference.md
@@ -76,3 +76,5 @@ node dist/cli.js usage-by-key \
 
 - `credit` and `redeem-promo` pass through the API response body unchanged.
 - Transaction history and usage analytics are useful for validating gateway metering behavior.
+- `usage-timeline` and `usage-by-model` accept either `--month` or a complete `--start-date` / `--end-date` range, but not both.
+- `usage-by-key` requires both `--start-date` and `--end-date`.

--- a/src/commands/usage-by-key.ts
+++ b/src/commands/usage-by-key.ts
@@ -1,5 +1,5 @@
 import { requestJson } from "../lib/api.js";
-import { appendDateRangeParams } from "../lib/history.js";
+import { appendRequiredDateRangeParams } from "../lib/history.js";
 import { resolvePortalContext, writeJson } from "../lib/keys.js";
 import { DEFAULT_SESSION_FILE } from "../lib/session.js";
 
@@ -19,7 +19,7 @@ export async function usageByKey(options: UsageByKeyOptions): Promise<void> {
   });
 
   const searchParams = new URLSearchParams();
-  appendDateRangeParams(searchParams, {
+  appendRequiredDateRangeParams(searchParams, {
     startDate: options.startDate,
     endDate: options.endDate,
   });

--- a/src/commands/usage-by-model.ts
+++ b/src/commands/usage-by-model.ts
@@ -1,5 +1,5 @@
 import { requestJson } from "../lib/api.js";
-import { appendDateRangeParams } from "../lib/history.js";
+import { appendMonthOrDateRangeParams } from "../lib/history.js";
 import { resolvePortalContext, writeJson } from "../lib/keys.js";
 import { DEFAULT_SESSION_FILE } from "../lib/session.js";
 
@@ -20,7 +20,7 @@ export async function usageByModel(options: UsageByModelOptions): Promise<void> 
   });
 
   const searchParams = new URLSearchParams();
-  appendDateRangeParams(searchParams, {
+  appendMonthOrDateRangeParams(searchParams, {
     startDate: options.startDate,
     endDate: options.endDate,
     month: options.month,

--- a/src/commands/usage-timeline.ts
+++ b/src/commands/usage-timeline.ts
@@ -1,5 +1,5 @@
 import { requestJson } from "../lib/api.js";
-import { appendDateRangeParams } from "../lib/history.js";
+import { appendMonthOrDateRangeParams } from "../lib/history.js";
 import { resolvePortalContext, writeJson } from "../lib/keys.js";
 import { DEFAULT_SESSION_FILE } from "../lib/session.js";
 
@@ -20,7 +20,7 @@ export async function usageTimeline(options: UsageTimelineOptions): Promise<void
   });
 
   const searchParams = new URLSearchParams();
-  appendDateRangeParams(searchParams, {
+  appendMonthOrDateRangeParams(searchParams, {
     startDate: options.startDate,
     endDate: options.endDate,
     month: options.month,

--- a/src/lib/history.ts
+++ b/src/lib/history.ts
@@ -51,6 +51,43 @@ export function appendDateRangeParams(
   }
 }
 
+export function appendMonthOrDateRangeParams(
+  searchParams: URLSearchParams,
+  params: { startDate?: string; endDate?: string; month?: string }
+): void {
+  const hasMonth = params.month !== undefined;
+  const hasStartDate = params.startDate !== undefined;
+  const hasEndDate = params.endDate !== undefined;
+
+  if (hasMonth && (hasStartDate || hasEndDate)) {
+    throw new CliError("Use either --month or --start-date/--end-date, but not both.");
+  }
+
+  if (hasStartDate !== hasEndDate) {
+    throw new CliError("Provide both --start-date and --end-date for an explicit date range.");
+  }
+
+  appendDateRangeParams(searchParams, params);
+}
+
+export function appendRequiredDateRangeParams(
+  searchParams: URLSearchParams,
+  params: { startDate?: string; endDate?: string }
+): void {
+  const hasStartDate = params.startDate !== undefined;
+  const hasEndDate = params.endDate !== undefined;
+
+  if (!hasStartDate && !hasEndDate) {
+    throw new CliError("Provide both --start-date and --end-date.");
+  }
+
+  if (hasStartDate !== hasEndDate) {
+    throw new CliError("Provide both --start-date and --end-date.");
+  }
+
+  appendDateRangeParams(searchParams, params);
+}
+
 export function parseTransactionFilterType(type: string): TransactionFilterType {
   const normalized = type.trim().toLowerCase();
   if ((TRANSACTION_FILTER_TYPES as readonly string[]).includes(normalized)) {


### PR DESCRIPTION
## Summary
- enforce the documented usage filter contracts in the CLI before making requests
- reject mixing `--month` with explicit `--start-date` / `--end-date` in `usage-timeline` and `usage-by-model`
- require a complete explicit date range in `usage-by-key`
- tighten the focused billing skill docs so they explicitly say "complete explicit date range"

## Testing
- `npm run typecheck`
- `npm run build`
- `tmp=$(mktemp) && printf '{"baseUrl":"https://platform-api.altllm.ai","token":"FAKE_PORTAL_TOKEN","user":{"id":"u","email":"u@example.com"}}' > "$tmp" && node dist/cli.js usage-timeline --session-file "$tmp" --month 2026-03 --start-date 2026-03-01 --end-date 2026-03-31`
- `tmp=$(mktemp) && printf '{"baseUrl":"https://platform-api.altllm.ai","token":"FAKE_PORTAL_TOKEN","user":{"id":"u","email":"u@example.com"}}' > "$tmp" && node dist/cli.js usage-by-model --session-file "$tmp" --month 2026-03 --start-date 2026-03-01 --end-date 2026-03-31`
- `tmp=$(mktemp) && printf '{"baseUrl":"https://platform-api.altllm.ai","token":"FAKE_PORTAL_TOKEN","user":{"id":"u","email":"u@example.com"}}' > "$tmp" && node dist/cli.js usage-by-key --session-file "$tmp" --start-date 2026-03-01`
- `tmp=$(mktemp) && printf '{"baseUrl":"https://platform-api.altllm.ai","token":"FAKE_PORTAL_TOKEN","user":{"id":"u","email":"u@example.com"}}' > "$tmp" && node dist/cli.js usage-by-key --session-file "$tmp"`

Closes #39.
