### PR TITLE
docs(payments): clarify payment link lookup limits

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,7 +439,8 @@ node dist/cli.js pay-payment-link \
 - `pay-payment-link --wait` prints one final JSON document.
 - The CLI does not silently downgrade from direct payment mode to hosted checkout mode.
 - Terminal payment-link statuses such as `completed`, `expired`, `failed`, and `deactivated` are rejected before direct payment is sent.
-- Payment-link lookup currently scans the most recent `100` Portal payment links via `GET /api/billing/payment-links?limit=100`.
+- `payment-status` and `pay-payment-link` currently depend on the newest `100` Portal payment links exposed by `GET /api/billing/payment-links?limit=100`.
+- Older payment links may be unreachable from the CLI until the backend exposes either lookup by ID or older-page pagination.
 
 ## HTTP Timeouts
 

--- a/skills/altllm-portal-payments/SKILL.md
+++ b/skills/altllm-portal-payments/SKILL.md
@@ -28,7 +28,8 @@ Payment-link creation, settlement polling, and direct wallet payment flows for t
 - `pay-payment-link` must not pay terminal links (`completed`, `expired`, `failed`, `deactivated`).
 - Do not silently downgrade from direct payment to hosted checkout.
 - `pay-payment-link --wait` should emit one final JSON document.
-- Payment-link lookup currently depends on the Portal `GET /api/billing/payment-links?limit=100` view because the backend does not expose per-link lookup or offset pagination.
+- `payment-status` and `pay-payment-link` currently depend on the newest `100` records from `GET /api/billing/payment-links?limit=100`.
+- Older payment links are not reachable from these CLI flows until the backend exposes per-link lookup or older-page pagination.
 - Supported direct-payment currencies are:
   - `eth`
   - `usdterc20`

--- a/skills/altllm-portal-payments/references/cli-reference.md
+++ b/skills/altllm-portal-payments/references/cli-reference.md
@@ -43,5 +43,6 @@ node dist/cli.js pay-payment-link \
 
 ## Notes
 
-- Payment-link lookup currently uses the recent Portal payment-links list (`limit=100`).
+- `payment-status` and `pay-payment-link` currently only search the newest `100` Portal payment links.
+- Older payment links are not reachable from these CLI flows until the backend supports lookup by ID or older-page pagination.
 - Automatic payment requires `pay_address`, `pay_amount`, and `pay_currency` to be present in the API response.

--- a/src/commands/topup-crypto.ts
+++ b/src/commands/topup-crypto.ts
@@ -91,7 +91,7 @@ export async function fetchPaymentLinkStatus(
   }
 
   throw new CliError(
-    `Payment link not found in the recent ${PAYMENT_LINK_LOOKUP_LIMIT} Portal payment links: ${paymentLinkId}`
+    `Payment link ${paymentLinkId} was not found in the newest ${PAYMENT_LINK_LOOKUP_LIMIT} Portal payment links. The current backend only exposes the latest payment-links list and does not support lookup by paymentLinkId or older-page pagination, so older links are not reachable from payment-status/pay-payment-link yet.`
   );
 }
 


### PR DESCRIPTION
## Summary
- clarify the payment-link lookup limitation instead of implying a stronger capability than the backend currently supports
- improve the CLI error message when a target payment link is not present in the newest 100 records
- tighten README and payment skill docs so `payment-status` / `pay-payment-link` are clearly described as only reliable for the newest 100 links until the backend grows lookup-by-id or older-page pagination

## Why this approach
The current backend only supports:
- `GET /api/billing/payment-links?limit=<n>`
- with `limit <= 100`
- no `offset`
- no lookup by `paymentLinkId`

So the CLI cannot actually page older records today. This change makes the limitation explicit and makes lookup failures explain the backend dependency instead of looking like a generic missing-ID error.

## Testing
- `npm run typecheck`
- `npm run build`
- start a local mock server that returns a payment-links list not containing the target ID
- `node -e "import('./dist/commands/topup-crypto.js').then(async (m) => { try { await m.fetchPaymentLinkStatus('http://127.0.0.1:18094', 'fake-token', 'missing-link'); process.exit(1); } catch (error) { const message = error instanceof Error ? error.message : String(error); console.log(message); process.exit(message.includes('missing-link') && message.includes('newest 100 Portal payment links') && message.includes('older links are not reachable') ? 0 : 1); } })"`

Closes #40.
