### PR TITLE
fix(api): wrap network fetch failures with context

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -55,7 +55,9 @@ export async function fetchWithTimeout(params: {
       );
     }
 
-    throw error;
+    const detail =
+      error instanceof Error && error.message ? error.message : String(error);
+    throw new CliError(`${params.method} ${params.url} failed: ${detail}`);
   } finally {
     clearTimeout(timer);
   }


### PR DESCRIPTION
## Summary
- wrap non-timeout fetch failures in `fetchWithTimeout()` as `CliError`
- preserve method + URL context for unreachable hosts and other network-level fetch failures
- keep the existing timeout-specific error path intact

## Testing
- `npm run typecheck`
- `npm run build`
- `tmp=$(mktemp) && printf '{"baseUrl":"http://127.0.0.1:9","token":"fake-token","user":{"id":"u","email":"u@example.com"}}' > "$tmp" && node dist/cli.js credit --session-file "$tmp"`

## Validation
The CLI now reports:
- `GET http://127.0.0.1:9/api/billing/balance failed: fetch failed`

instead of only:
- `fetch failed`

Closes #41.
