### PR TITLE
fix(origin): canonicalize default ports in host checks

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -11,6 +11,24 @@ export function normalizeBaseUrl(baseUrl: string): string {
   return baseUrl.replace(/\/+$/, "");
 }
 
+export function canonicalizeOrigin(baseUrl: string): string {
+  let parsed: URL;
+  try {
+    parsed = new URL(normalizeBaseUrl(baseUrl));
+  } catch {
+    throw new CliError(`Invalid base URL: ${baseUrl}`);
+  }
+
+  const protocol = parsed.protocol.toLowerCase();
+  const hostname = parsed.hostname.toLowerCase();
+  const defaultPort =
+    protocol === "https:" ? "443" : protocol === "http:" ? "80" : "";
+  const portSuffix =
+    parsed.port && parsed.port !== defaultPort ? `:${parsed.port}` : "";
+
+  return `${protocol}//${hostname}${portSuffix}`;
+}
+
 function resolveRequestTimeoutMs(): number {
   const raw = process.env.ALTLLM_HTTP_TIMEOUT_MS?.trim();
   if (!raw) {

--- a/src/lib/cloud-claw.ts
+++ b/src/lib/cloud-claw.ts
@@ -1,4 +1,9 @@
-import { CliError, normalizeBaseUrl, requestJson } from "./api.js";
+import {
+  canonicalizeOrigin,
+  CliError,
+  normalizeBaseUrl,
+  requestJson,
+} from "./api.js";
 import { DEFAULT_SESSION_FILE, loadSession } from "./session.js";
 
 export const TRUSTED_CLOUD_CLAW_BASE_URL = "https://claw.altllm.ai";
@@ -20,9 +25,11 @@ function ensureCloudClawBaseUrlAllowed(params: {
   const normalizedTrustedBaseUrl = normalizeCloudClawBaseUrl(
     TRUSTED_CLOUD_CLAW_BASE_URL
   );
+  const canonicalBaseUrlOrigin = canonicalizeOrigin(normalizedBaseUrl);
+  const canonicalTrustedOrigin = canonicalizeOrigin(normalizedTrustedBaseUrl);
 
   if (
-    normalizedBaseUrl !== normalizedTrustedBaseUrl &&
+    canonicalBaseUrlOrigin !== canonicalTrustedOrigin &&
     !params.allowTokenForwarding
   ) {
     throw new CliError(

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -2,7 +2,7 @@ import { mkdir, readFile, unlink, writeFile } from "node:fs/promises";
 import { dirname } from "node:path";
 import { homedir } from "node:os";
 
-import { CliError, normalizeBaseUrl } from "./api.js";
+import { canonicalizeOrigin, CliError, normalizeBaseUrl } from "./api.js";
 
 export interface PortalSession {
   baseUrl: string;
@@ -25,9 +25,11 @@ export function resolveSessionBackedBaseUrl(params: {
   const normalizedBaseUrl = normalizeBaseUrl(
     params.baseUrl || params.sessionBaseUrl
   );
+  const canonicalSessionOrigin = canonicalizeOrigin(normalizedSessionBaseUrl);
+  const canonicalRequestedOrigin = canonicalizeOrigin(normalizedBaseUrl);
 
   if (
-    normalizedBaseUrl !== normalizedSessionBaseUrl &&
+    canonicalRequestedOrigin !== canonicalSessionOrigin &&
     !params.allowTokenHostMismatch
   ) {
     throw new CliError(


### PR DESCRIPTION
## Summary
- compare canonical origins instead of raw normalized base-url strings in the token host checks
- collapse default ports so semantically equivalent origins like `https://host` and `https://host:443` are treated as the same origin
- apply the fix to both Portal session host-mismatch checks and Cloud Claw trusted-host checks

## Testing
- `npm run typecheck`
- `npm run build`
- `node -e "import('./dist/lib/api.js').then((m) => { console.log(m.canonicalizeOrigin('https://platform-api.altllm.ai')); console.log(m.canonicalizeOrigin('https://platform-api.altllm.ai:443')); console.log(m.canonicalizeOrigin('http://example.com')); console.log(m.canonicalizeOrigin('http://example.com:80')); process.exit(m.canonicalizeOrigin('https://platform-api.altllm.ai') === m.canonicalizeOrigin('https://platform-api.altllm.ai:443') && m.canonicalizeOrigin('http://example.com') === m.canonicalizeOrigin('http://example.com:80') ? 0 : 1); })"`
- `node -e "import('./dist/lib/session.js').then((session) => { try { const resolved = session.resolveSessionBackedBaseUrl({ sessionBaseUrl: 'https://platform-api.altllm.ai', baseUrl: 'https://platform-api.altllm.ai:443' }); console.log(resolved); process.exit(resolved === 'https://platform-api.altllm.ai:443' ? 0 : 1); } catch (error) { console.error(error instanceof Error ? error.message : String(error)); process.exit(1); } })"`

Closes #42.
