### PR TITLE
fix(cloud-claw): avoid jwt in log stream URL

### DIFF
--- a/src/commands/cloud-claw-logs.ts
+++ b/src/commands/cloud-claw-logs.ts
@@ -38,8 +38,13 @@ export async function cloudClawLogs(options: CloudClawLogsOptions): Promise<void
   }
 
   const response = await fetch(
-    `${normalizeBaseUrl(baseUrl)}/api/vm/deployments/${name}/logs/stream?auth=${encodeURIComponent(jwt)}`,
-    { headers: { Accept: "text/event-stream" } }
+    `${normalizeBaseUrl(baseUrl)}/api/vm/deployments/${name}/logs/stream`,
+    {
+      headers: {
+        Accept: "text/event-stream",
+        Authorization: `Bearer ${jwt}`,
+      },
+    }
   );
 
   if (!response.ok || !response.body) {


### PR DESCRIPTION
## Summary
- stop putting the Cloud Claw JWT into the log-stream URL query string from the CLI
- send the JWT via `Authorization: Bearer ...` on the stream request instead
- keep the one-shot logs path unchanged because it already uses headers

## Testing
- `npm run typecheck`
- `npm run build`
- start a local mock Cloud Claw server that:
  - returns `JWT123` from `/api/auth/portal-sso`
  - echoes the incoming `url` and `authorization` header from `/api/vm/deployments/vm1/logs/stream` as SSE data
- `tmp=$(mktemp) && printf '{"baseUrl":"https://platform-api.altllm.ai","token":"fake-portal-token","user":{"id":"u","email":"u@example.com"}}' > "$tmp" && node dist/cli.js cloud-claw-logs --name vm1 --stream --session-file "$tmp" --cloud-claw-base-url http://127.0.0.1:18095 --allow-cloud-claw-token-forwarding`

## Validation
The streamed response showed:
- `url: /api/vm/deployments/vm1/logs/stream`
- `authorization: Bearer JWT123`

with no `?auth=` query parameter in the request URL.

Closes #43.
