### PR TITLE
fix(auth): validate wallet challenge before auto-signing

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,8 @@ Notes:
 
 - The CLI no longer assumes it must hold the user's private key.
 - External signers such as Privy are supported as long as they can sign the challenge message and return the wallet signature.
+- Local auto-signing now validates that the returned challenge matches the requested wallet, chain, and expected AltLLM login message shape before signing.
+- Automatic local signing is only allowed for the default production Portal API or loopback hosts. For other hosts, use `--prepare` and sign externally.
 - The current Portal backend still validates EVM addresses and Ethereum-style signatures.
 - If you run `login-wallet` without a local private key or `--signature`, it now returns a challenge payload instead of failing immediately.
 

--- a/skills/altllm-portal-auth/SKILL.md
+++ b/skills/altllm-portal-auth/SKILL.md
@@ -29,6 +29,8 @@ user-invocable: true
 - If the wallet can sign the challenge message, use the prepare + verify flow.
 - External signers such as Privy are valid as long as they return a standard wallet signature for the challenge.
 - If neither a local private key nor `--signature` is available, return the challenge payload and stop.
+- Before local auto-signing, validate that the returned challenge matches the requested wallet, chain, and expected AltLLM login challenge structure.
+- For non-default, non-loopback API hosts, prefer `--prepare` and external signing instead of local auto-signing.
 - Current backend support is still limited to EVM addresses and Ethereum-style signatures.
 - Save the resulting session to `~/.altllm/portal-cli-session.json` unless overridden.
 - `logout` only removes the local session file. It does not revoke API keys.

--- a/skills/altllm-portal-auth/references/cli-reference.md
+++ b/skills/altllm-portal-auth/references/cli-reference.md
@@ -64,6 +64,8 @@ node dist/cli.js login-wallet \
 
 - If no local private key and no signature are provided, `login-wallet` returns a challenge payload.
 - External signers such as Privy work if they can sign the returned challenge message for the supplied wallet address.
+- Local auto-signing validates the returned challenge before signing it.
+- For non-default, non-loopback API hosts, use `--prepare` and sign externally.
 - The current backend rejects non-EVM address formats.
 - Signature validation is Ethereum-style message recovery on the server.
 

--- a/src/commands/login-wallet.ts
+++ b/src/commands/login-wallet.ts
@@ -244,10 +244,6 @@ function validateChallengeMessageForAutoSign(params: {
         `Challenge URI mismatch. Expected ${TRUSTED_PORTAL_FRONTEND_ORIGIN}, got ${parsedMessage.uri.origin}.`
       );
     }
-  } else if (!isLoopbackHostname(parsedMessage.uri.hostname)) {
-    throw new CliError(
-      "Automatic wallet challenge signing on loopback APIs requires a loopback challenge URI."
-    );
   }
 }
 

--- a/src/commands/login-wallet.ts
+++ b/src/commands/login-wallet.ts
@@ -31,9 +31,223 @@ export interface LoginWalletOptions {
   sessionFile: string;
 }
 
+interface ParsedChallengeMessage {
+  domain: string;
+  walletAddress: string;
+  uri: URL;
+  chainId: number;
+  nonce: string;
+  issuedAt: string;
+  expiresAt: string;
+}
+
+const TRUSTED_PORTAL_API_ORIGIN = "https://platform-api.altllm.ai";
+const TRUSTED_PORTAL_FRONTEND_ORIGIN = "https://platform.altllm.ai";
+const CHALLENGE_MESSAGE_RE =
+  /^([^\n]+) wants you to sign in with your Ethereum account:\n(0x[a-fA-F0-9]{40})\n\nSign this message to log in to AltLLM Portal\.\n\nURI: ([^\n]+)\nVersion: ([^\n]+)\nChain ID: ([^\n]+)\nNonce: ([^\n]+)\nIssued At: ([^\n]+)\nExpiration Time: ([^\n]+)$/;
+
 function validateChainId(chainId: number): void {
   if (!Number.isFinite(chainId) || !Number.isInteger(chainId) || chainId <= 0) {
     throw new CliError("Chain ID must be a positive integer.");
+  }
+}
+
+function normalizeWalletAddress(walletAddress: string): string {
+  if (!/^0x[a-fA-F0-9]{40}$/.test(walletAddress)) {
+    throw new CliError("Wallet address must be a valid EVM address.");
+  }
+
+  return walletAddress.toLowerCase();
+}
+
+function canonicalizeOrigin(url: string): string {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new CliError(`Invalid URL in wallet challenge flow: ${url}`);
+  }
+
+  const protocol = parsed.protocol.toLowerCase();
+  const hostname = parsed.hostname.toLowerCase();
+  const defaultPort =
+    protocol === "https:" ? "443" : protocol === "http:" ? "80" : "";
+  const portSuffix =
+    parsed.port && parsed.port !== defaultPort ? `:${parsed.port}` : "";
+
+  return `${protocol}//${hostname}${portSuffix}`;
+}
+
+function isLoopbackHostname(hostname: string): boolean {
+  const normalized = hostname.toLowerCase();
+  return normalized === "localhost" || normalized === "127.0.0.1" || normalized === "::1";
+}
+
+function parseTimestamp(label: string, value: string): Date {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    throw new CliError(`${label} must be a valid ISO-8601 timestamp.`);
+  }
+
+  return date;
+}
+
+function validateChallengeResponseMetadata(params: {
+  requestedWalletAddress: string;
+  requestedChainId: number;
+  challenge: CryptoChallengeResponse;
+}): void {
+  const normalizedRequestedWalletAddress = normalizeWalletAddress(
+    params.requestedWalletAddress
+  );
+  const normalizedChallengeWalletAddress = normalizeWalletAddress(
+    params.challenge.wallet_address
+  );
+
+  if (normalizedChallengeWalletAddress !== normalizedRequestedWalletAddress) {
+    throw new CliError(
+      `Challenge wallet address mismatch. Expected ${normalizedRequestedWalletAddress}, got ${normalizedChallengeWalletAddress}.`
+    );
+  }
+
+  if (params.challenge.chain_id !== params.requestedChainId) {
+    throw new CliError(
+      `Challenge chain ID mismatch. Expected ${params.requestedChainId}, got ${params.challenge.chain_id}.`
+    );
+  }
+
+  if (!params.challenge.nonce.trim()) {
+    throw new CliError("Challenge nonce cannot be empty.");
+  }
+
+  const expiresAt = parseTimestamp(
+    "Challenge expiration time",
+    params.challenge.expires_at
+  );
+  if (expiresAt.getTime() <= Date.now()) {
+    throw new CliError("Challenge is already expired.");
+  }
+}
+
+function parseChallengeMessage(message: string): ParsedChallengeMessage {
+  const normalizedMessage = message.replace(/\r\n/g, "\n");
+  const match = normalizedMessage.match(CHALLENGE_MESSAGE_RE);
+  if (!match) {
+    throw new CliError(
+      "Challenge message is not a valid AltLLM Portal login challenge."
+    );
+  }
+
+  const [
+    ,
+    domain,
+    walletAddress,
+    uriText,
+    version,
+    chainIdText,
+    nonce,
+    issuedAt,
+    expiresAt,
+  ] = match;
+
+  if (version !== "1") {
+    throw new CliError(`Unsupported challenge version: ${version}.`);
+  }
+
+  const chainId = Number(chainIdText);
+  validateChainId(chainId);
+
+  let uri: URL;
+  try {
+    uri = new URL(uriText);
+  } catch {
+    throw new CliError(`Challenge URI is invalid: ${uriText}`);
+  }
+
+  return {
+    domain,
+    walletAddress: normalizeWalletAddress(walletAddress),
+    uri,
+    chainId,
+    nonce,
+    issuedAt,
+    expiresAt,
+  };
+}
+
+function validateChallengeMessageForAutoSign(params: {
+  baseUrl: string;
+  requestedWalletAddress: string;
+  requestedChainId: number;
+  challenge: CryptoChallengeResponse;
+}): void {
+  const apiOrigin = canonicalizeOrigin(params.baseUrl);
+  const isTrustedProductionApi = apiOrigin === TRUSTED_PORTAL_API_ORIGIN;
+  const apiHostname = new URL(params.baseUrl).hostname;
+  const isLoopbackApi = isLoopbackHostname(apiHostname);
+
+  if (!isTrustedProductionApi && !isLoopbackApi) {
+    throw new CliError(
+      `Automatic wallet challenge signing is only allowed for ${TRUSTED_PORTAL_API_ORIGIN} or loopback hosts. Re-run with --prepare to sign externally.`
+    );
+  }
+
+  const parsedMessage = parseChallengeMessage(params.challenge.message);
+  const normalizedRequestedWalletAddress = normalizeWalletAddress(
+    params.requestedWalletAddress
+  );
+
+  if (parsedMessage.walletAddress !== normalizedRequestedWalletAddress) {
+    throw new CliError(
+      `Challenge message wallet mismatch. Expected ${normalizedRequestedWalletAddress}, got ${parsedMessage.walletAddress}.`
+    );
+  }
+
+  if (parsedMessage.chainId !== params.requestedChainId) {
+    throw new CliError(
+      `Challenge message chain ID mismatch. Expected ${params.requestedChainId}, got ${parsedMessage.chainId}.`
+    );
+  }
+
+  if (parsedMessage.nonce !== params.challenge.nonce) {
+    throw new CliError("Challenge message nonce does not match challenge metadata.");
+  }
+
+  if (parsedMessage.expiresAt !== params.challenge.expires_at) {
+    throw new CliError(
+      "Challenge message expiration time does not match challenge metadata."
+    );
+  }
+
+  if (parsedMessage.domain !== parsedMessage.uri.hostname) {
+    throw new CliError("Challenge domain does not match challenge URI hostname.");
+  }
+
+  const issuedAt = parseTimestamp(
+    "Challenge issued-at time",
+    parsedMessage.issuedAt
+  );
+  const expiresAt = parseTimestamp(
+    "Challenge expiration time",
+    parsedMessage.expiresAt
+  );
+
+  if (issuedAt.getTime() >= expiresAt.getTime()) {
+    throw new CliError(
+      "Challenge issued-at time must be earlier than expiration time."
+    );
+  }
+
+  if (isTrustedProductionApi) {
+    if (canonicalizeOrigin(parsedMessage.uri.toString()) !== TRUSTED_PORTAL_FRONTEND_ORIGIN) {
+      throw new CliError(
+        `Challenge URI mismatch. Expected ${TRUSTED_PORTAL_FRONTEND_ORIGIN}, got ${parsedMessage.uri.origin}.`
+      );
+    }
+  } else if (!isLoopbackHostname(parsedMessage.uri.hostname)) {
+    throw new CliError(
+      "Automatic wallet challenge signing on loopback APIs requires a loopback challenge URI."
+    );
   }
 }
 
@@ -41,9 +255,7 @@ export async function loginWallet(options: LoginWalletOptions): Promise<void> {
   const baseUrl = normalizeBaseUrl(options.baseUrl);
   const walletAddress = options.walletAddress.trim();
 
-  if (!/^0x[a-fA-F0-9]{40}$/.test(walletAddress)) {
-    throw new CliError("Wallet address must be a valid EVM address.");
-  }
+  normalizeWalletAddress(walletAddress);
 
   if (options.signature) {
     if (!options.nonce?.trim()) {
@@ -91,6 +303,12 @@ export async function loginWallet(options: LoginWalletOptions): Promise<void> {
     },
   });
 
+  validateChallengeResponseMetadata({
+    requestedWalletAddress: walletAddress,
+    requestedChainId: options.chainId,
+    challenge,
+  });
+
   if (options.prepare) {
     process.stdout.write(
       `${JSON.stringify(
@@ -134,6 +352,12 @@ export async function loginWallet(options: LoginWalletOptions): Promise<void> {
   }
 
   const privateKey = resolvePrivateKey(options.privateKey, options.privateKeyEnv);
+  validateChallengeMessageForAutoSign({
+    baseUrl,
+    requestedWalletAddress: walletAddress,
+    requestedChainId: options.chainId,
+    challenge,
+  });
   const signature = await signChallengeMessage(privateKey, challenge.message);
 
   const login = await requestJson<LoginResponse>({


### PR DESCRIPTION
## Summary
- validate the wallet challenge metadata before auto-signing
- validate that the challenge message itself is a well-formed AltLLM Portal login challenge bound to the requested wallet, chain ID, nonce, and expiration time
- only allow local automatic signing for the default production Portal API or loopback hosts
- direct non-default, non-loopback hosts to the safer `--prepare` external-signing flow
- document the new local auto-signing guardrails in the auth docs

## Testing
- `npm run typecheck`
- `npm run build`
- start a local mock server on `127.0.0.1:18096` that returns a matching wallet/chain/nonce payload but an arbitrary message string and verify that:
  - `ALTLLM_WALLET_PRIVATE_KEY=1111111111111111111111111111111111111111111111111111111111111111 node dist/cli.js login-wallet --base-url http://127.0.0.1:18096 --wallet-address 0x1111111111111111111111111111111111111111`
  - fails locally with `Challenge message is not a valid AltLLM Portal login challenge.`
- start a local mock server on `127.0.0.1:18097` that returns a valid loopback-formatted challenge and a successful `/crypto/verify` response, then verify that:
  - `ALTLLM_WALLET_PRIVATE_KEY=1111111111111111111111111111111111111111111111111111111111111111 node dist/cli.js login-wallet --base-url http://127.0.0.1:18097 --wallet-address 0x1111111111111111111111111111111111111111 --session-file <tmp>`
  - completes successfully and saves the session

Closes #44.
