### PR TITLE
docs(repo): ignore local env files by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 node_modules/
 dist/
 .DS_Store
-
+.env
+.env.*
+*.env

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,6 +120,7 @@ Only supported EVM-compatible `pay_currency` values should be auto-paid. Unsuppo
 ## Security
 
 - Never commit secrets, private keys, session files, or local env files.
+- Common local `.env`-style files are gitignored, but still treat them as sensitive local-only state.
 - Treat `~/.altllm/portal-cli-session.json` as sensitive local state.
 - Prefer environment variables such as `ALTLLM_WALLET_PRIVATE_KEY` over inline secret arguments.
 - If the wallet signs externally, prefer challenge + signature verification flow instead of requiring the raw private key locally.


### PR DESCRIPTION
## Summary
- ignore common local `.env`-style files by default
- align repo behavior with the existing security guidance that says local env files should not be committed
- add a short AGENTS note that these files are gitignored but still sensitive local-only state

## Testing
- verified `.gitignore` now includes:
  - `.env`
  - `.env.*`
  - `*.env`
- reviewed `AGENTS.md` security guidance for consistency with the new ignore rules

Closes #45.
