### PR TITLE
fix(wallet): add non-argv private key inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,13 @@ node dist/cli.js logout
 
 Use `ALTLLM_WALLET_PRIVATE_KEY` instead of passing `--private-key` inline whenever possible.
 
+Safer local private-key input paths:
+
+- `--private-key-env <ENV_NAME>`
+- `--private-key-file <path>`
+
+Direct `--private-key` usage is still available for compatibility, but now requires `--allow-unsafe-private-key-argv`.
+
 If the wallet can sign but you do not control its private key locally, prepare a challenge first:
 
 ```bash
@@ -442,6 +449,13 @@ node dist/cli.js pay-payment-link \
   --payment-link-id <id> \
   --wait
 ```
+
+Safer wallet private-key input paths for payment commands:
+
+- `--private-key-env <ENV_NAME>`
+- `--private-key-file <path>`
+
+Direct `--private-key` usage now requires `--allow-unsafe-private-key-argv`.
 
 ## Payment Behavior
 

--- a/skills/altllm-portal-auth/references/cli-reference.md
+++ b/skills/altllm-portal-auth/references/cli-reference.md
@@ -25,6 +25,13 @@ Representative stdout:
 }
 ```
 
+Safer key input paths:
+
+- `--private-key-env <ENV_NAME>`
+- `--private-key-file <path>`
+
+Direct `--private-key` usage now requires `--allow-unsafe-private-key-argv`.
+
 ### Prepare challenge for external signing
 
 ```bash
@@ -66,6 +73,7 @@ node dist/cli.js login-wallet \
 - External signers such as Privy work if they can sign the returned challenge message for the supplied wallet address.
 - Local auto-signing validates the returned challenge before signing it.
 - For non-default, non-loopback API hosts, use `--prepare` and sign externally.
+- Safer local private-key input paths are `--private-key-env` and `--private-key-file`.
 - The current backend rejects non-EVM address formats.
 - Signature validation is Ethereum-style message recovery on the server.
 

--- a/skills/altllm-portal-payments/references/cli-reference.md
+++ b/skills/altllm-portal-payments/references/cli-reference.md
@@ -41,6 +41,13 @@ node dist/cli.js pay-payment-link \
   --wait
 ```
 
+Safer key input paths for payment commands:
+
+- `--private-key-env <ENV_NAME>`
+- `--private-key-file <path>`
+
+Direct `--private-key` usage now requires `--allow-unsafe-private-key-argv`.
+
 ## Notes
 
 - `payment-status` and `pay-payment-link` currently only search the newest `100` Portal payment links.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -40,6 +40,8 @@ const CLOUD_CLAW_TOKEN_FORWARDING_OPTION =
   "Allow forwarding the saved Portal session token to a non-default Cloud Claw base URL";
 const PORTAL_TOKEN_HOST_MISMATCH_OPTION =
   "Allow sending the saved Portal session token to a non-session --base-url";
+const UNSAFE_PRIVATE_KEY_ARGV_OPTION =
+  "Allow reading the wallet private key directly from --private-key (unsafe: leaks via argv)";
 
 function collectOptionValues(value: string, previous?: string[]): string[] {
   return [...(previous ?? []), value];
@@ -88,7 +90,9 @@ program
     process.env.ALTLLM_PORTAL_API_URL || "https://platform-api.altllm.ai"
   )
   .option("--private-key <hex>", "EVM private key for local signing")
+  .option("--private-key-file <path>", "File containing the private key for local signing")
   .option("--private-key-env <name>", "Environment variable containing the private key for local signing", "ALTLLM_WALLET_PRIVATE_KEY")
+  .option("--allow-unsafe-private-key-argv", UNSAFE_PRIVATE_KEY_ARGV_OPTION, false)
   .option("--chain-id <number>", "Chain ID for the login challenge", "1")
   .option("--prepare", "Fetch a wallet challenge for an external signer such as Privy", false)
   .option("--nonce <value>", "Existing challenge nonce for external-signature login")
@@ -99,7 +103,9 @@ program
       baseUrl: options.baseUrl,
       walletAddress: options.walletAddress,
       privateKey: options.privateKey,
+      privateKeyFile: options.privateKeyFile,
       privateKeyEnv: options.privateKeyEnv,
+      allowUnsafePrivateKeyArgv: Boolean(options.allowUnsafePrivateKeyArgv),
       chainId: parsePositiveIntegerOption(options.chainId, "--chain-id"),
       prepare: Boolean(options.prepare),
       nonce: options.nonce,
@@ -541,7 +547,9 @@ program
   .option("--pay-currency <ticker>", "NOWPayments pay_currency for direct payment mode")
   .option("--auto-pay", "Automatically send the on-chain payment from the local wallet", false)
   .option("--private-key <hex>", "EVM private key for automatic payment")
+  .option("--private-key-file <path>", "File containing the private key for automatic payment")
   .option("--private-key-env <name>", "Environment variable containing the private key", "ALTLLM_WALLET_PRIVATE_KEY")
+  .option("--allow-unsafe-private-key-argv", UNSAFE_PRIVATE_KEY_ARGV_OPTION, false)
   .option("--redirect-url <url>", "Optional redirect URL after payment")
   .option("--session-file <path>", "Path to the saved Portal session", DEFAULT_SESSION_FILE)
   .option("--allow-token-host-mismatch", PORTAL_TOKEN_HOST_MISMATCH_OPTION, false)
@@ -555,7 +563,9 @@ program
       payCurrency: options.payCurrency,
       autoPay: Boolean(options.autoPay),
       privateKey: options.privateKey,
+      privateKeyFile: options.privateKeyFile,
       privateKeyEnv: options.privateKeyEnv,
+      allowUnsafePrivateKeyArgv: Boolean(options.allowUnsafePrivateKeyArgv),
       redirectUrl: options.redirectUrl,
       sessionFile: options.sessionFile,
       allowTokenHostMismatch: Boolean(options.allowTokenHostMismatch),
@@ -599,7 +609,9 @@ program
   .option("--session-file <path>", "Path to the saved Portal session", DEFAULT_SESSION_FILE)
   .option("--allow-token-host-mismatch", PORTAL_TOKEN_HOST_MISMATCH_OPTION, false)
   .option("--private-key <hex>", "EVM private key for automatic payment")
+  .option("--private-key-file <path>", "File containing the private key for automatic payment")
   .option("--private-key-env <name>", "Environment variable containing the private key", "ALTLLM_WALLET_PRIVATE_KEY")
+  .option("--allow-unsafe-private-key-argv", UNSAFE_PRIVATE_KEY_ARGV_OPTION, false)
   .option("--wait", "Poll until the payment reaches a terminal state after broadcast", false)
   .option("--poll-interval <seconds>", "Polling interval in seconds", "10")
   .option("--timeout <seconds>", "Maximum wait time in seconds", "600")
@@ -610,7 +622,9 @@ program
       sessionFile: options.sessionFile,
       allowTokenHostMismatch: Boolean(options.allowTokenHostMismatch),
       privateKey: options.privateKey,
+      privateKeyFile: options.privateKeyFile,
       privateKeyEnv: options.privateKeyEnv,
+      allowUnsafePrivateKeyArgv: Boolean(options.allowUnsafePrivateKeyArgv),
       wait: Boolean(options.wait),
       pollIntervalSeconds: parsePositiveNumberOption(
         options.pollInterval,

--- a/src/commands/login-wallet.ts
+++ b/src/commands/login-wallet.ts
@@ -1,6 +1,10 @@
 import { CliError, normalizeBaseUrl, requestJson } from "../lib/api.js";
 import { DEFAULT_SESSION_FILE, saveSession } from "../lib/session.js";
-import { normalizeWalletSignature, resolvePrivateKey, signChallengeMessage } from "../lib/wallet.js";
+import {
+  normalizeWalletSignature,
+  resolvePrivateKey,
+  signChallengeMessage,
+} from "../lib/wallet.js";
 
 interface CryptoChallengeResponse {
   wallet_address: string;
@@ -23,7 +27,9 @@ export interface LoginWalletOptions {
   baseUrl: string;
   walletAddress: string;
   privateKey?: string;
+  privateKeyFile?: string;
   privateKeyEnv: string;
+  allowUnsafePrivateKeyArgv?: boolean;
   chainId: number;
   prepare?: boolean;
   nonce?: string;
@@ -325,7 +331,9 @@ export async function loginWallet(options: LoginWalletOptions): Promise<void> {
   }
 
   const hasLocalPrivateKey = Boolean(
-    options.privateKey?.trim() || process.env[options.privateKeyEnv]?.trim()
+    options.privateKey?.trim() ||
+      options.privateKeyFile?.trim() ||
+      process.env[options.privateKeyEnv]?.trim()
   );
 
   if (!hasLocalPrivateKey) {
@@ -347,7 +355,12 @@ export async function loginWallet(options: LoginWalletOptions): Promise<void> {
     return;
   }
 
-  const privateKey = resolvePrivateKey(options.privateKey, options.privateKeyEnv);
+  const privateKey = await resolvePrivateKey({
+    explicit: options.privateKey,
+    filePath: options.privateKeyFile,
+    envName: options.privateKeyEnv,
+    allowUnsafeArgv: options.allowUnsafePrivateKeyArgv,
+  });
   validateChallengeMessageForAutoSign({
     baseUrl,
     requestedWalletAddress: walletAddress,

--- a/src/commands/pay-payment-link.ts
+++ b/src/commands/pay-payment-link.ts
@@ -4,7 +4,11 @@ import {
   loadSession,
   resolveSessionBackedBaseUrl,
 } from "../lib/session.js";
-import { executeDirectPayment, resolvePrivateKey } from "../lib/wallet.js";
+import {
+  executeDirectPayment,
+  resolvePrivateKey,
+  validateUnsafePrivateKeyArgvUsage,
+} from "../lib/wallet.js";
 import {
   fetchPaymentLinkStatus,
   formatPaymentLinkRecord,
@@ -18,7 +22,9 @@ export interface PayPaymentLinkOptions {
   baseUrl?: string;
   sessionFile: string;
   privateKey?: string;
+  privateKeyFile?: string;
   privateKeyEnv: string;
+  allowUnsafePrivateKeyArgv?: boolean;
   wait?: boolean;
   pollIntervalSeconds: number;
   timeoutSeconds: number;
@@ -26,6 +32,11 @@ export interface PayPaymentLinkOptions {
 }
 
 export async function payPaymentLink(options: PayPaymentLinkOptions): Promise<void> {
+  validateUnsafePrivateKeyArgvUsage({
+    explicit: options.privateKey,
+    allowUnsafeArgv: options.allowUnsafePrivateKeyArgv,
+  });
+
   if (options.wait) {
     validatePaymentPollingOptions({
       pollIntervalSeconds: options.pollIntervalSeconds,
@@ -55,7 +66,12 @@ export async function payPaymentLink(options: PayPaymentLinkOptions): Promise<vo
     );
   }
 
-  const privateKey = resolvePrivateKey(options.privateKey, options.privateKeyEnv);
+  const privateKey = await resolvePrivateKey({
+    explicit: options.privateKey,
+    filePath: options.privateKeyFile,
+    envName: options.privateKeyEnv,
+    allowUnsafeArgv: options.allowUnsafePrivateKeyArgv,
+  });
   const payment = await executeDirectPayment({
     privateKey,
     payAddress: link.pay_address,

--- a/src/commands/pay-payment-link.ts
+++ b/src/commands/pay-payment-link.ts
@@ -4,11 +4,7 @@ import {
   loadSession,
   resolveSessionBackedBaseUrl,
 } from "../lib/session.js";
-import {
-  executeDirectPayment,
-  resolvePrivateKey,
-  validateUnsafePrivateKeyArgvUsage,
-} from "../lib/wallet.js";
+import { executeDirectPayment, resolvePrivateKey } from "../lib/wallet.js";
 import {
   fetchPaymentLinkStatus,
   formatPaymentLinkRecord,
@@ -32,11 +28,6 @@ export interface PayPaymentLinkOptions {
 }
 
 export async function payPaymentLink(options: PayPaymentLinkOptions): Promise<void> {
-  validateUnsafePrivateKeyArgvUsage({
-    explicit: options.privateKey,
-    allowUnsafeArgv: options.allowUnsafePrivateKeyArgv,
-  });
-
   if (options.wait) {
     validatePaymentPollingOptions({
       pollIntervalSeconds: options.pollIntervalSeconds,

--- a/src/commands/topup-crypto.ts
+++ b/src/commands/topup-crypto.ts
@@ -4,11 +4,7 @@ import {
   loadSession,
   resolveSessionBackedBaseUrl,
 } from "../lib/session.js";
-import {
-  executeDirectPayment,
-  resolvePrivateKey,
-  validateUnsafePrivateKeyArgvUsage,
-} from "../lib/wallet.js";
+import { executeDirectPayment, resolvePrivateKey } from "../lib/wallet.js";
 
 export interface TopupCryptoOptions {
   amount: number;
@@ -181,11 +177,6 @@ export async function topupCrypto(options: TopupCryptoOptions): Promise<void> {
   if (!Number.isFinite(options.amount) || options.amount < 0.5) {
     throw new CliError("Amount must be >= 0.5 USD.");
   }
-
-  validateUnsafePrivateKeyArgvUsage({
-    explicit: options.privateKey,
-    allowUnsafeArgv: options.allowUnsafePrivateKeyArgv,
-  });
 
   if (options.wait) {
     validatePaymentPollingOptions({

--- a/src/commands/topup-crypto.ts
+++ b/src/commands/topup-crypto.ts
@@ -4,7 +4,11 @@ import {
   loadSession,
   resolveSessionBackedBaseUrl,
 } from "../lib/session.js";
-import { executeDirectPayment, resolvePrivateKey } from "../lib/wallet.js";
+import {
+  executeDirectPayment,
+  resolvePrivateKey,
+  validateUnsafePrivateKeyArgvUsage,
+} from "../lib/wallet.js";
 
 export interface TopupCryptoOptions {
   amount: number;
@@ -13,7 +17,9 @@ export interface TopupCryptoOptions {
   payCurrency?: string;
   autoPay?: boolean;
   privateKey?: string;
+  privateKeyFile?: string;
   privateKeyEnv: string;
+  allowUnsafePrivateKeyArgv?: boolean;
   sessionFile: string;
   wait?: boolean;
   pollIntervalSeconds: number;
@@ -176,6 +182,11 @@ export async function topupCrypto(options: TopupCryptoOptions): Promise<void> {
     throw new CliError("Amount must be >= 0.5 USD.");
   }
 
+  validateUnsafePrivateKeyArgvUsage({
+    explicit: options.privateKey,
+    allowUnsafeArgv: options.allowUnsafePrivateKeyArgv,
+  });
+
   if (options.wait) {
     validatePaymentPollingOptions({
       pollIntervalSeconds: options.pollIntervalSeconds,
@@ -224,7 +235,12 @@ export async function topupCrypto(options: TopupCryptoOptions): Promise<void> {
       );
     }
 
-    const privateKey = resolvePrivateKey(options.privateKey, options.privateKeyEnv);
+    const privateKey = await resolvePrivateKey({
+      explicit: options.privateKey,
+      filePath: options.privateKeyFile,
+      envName: options.privateKeyEnv,
+      allowUnsafeArgv: options.allowUnsafePrivateKeyArgv,
+    });
     const payment = await executeDirectPayment({
       privateKey,
       payAddress: created.pay_address,

--- a/src/lib/wallet.ts
+++ b/src/lib/wallet.ts
@@ -11,20 +11,76 @@ import {
 } from "viem";
 import { base, mainnet } from "viem/chains";
 import { privateKeyToAccount } from "viem/accounts";
+import { readFile } from "node:fs/promises";
 
 import { CliError } from "./api.js";
 
-export function resolvePrivateKey(explicit?: string, envName = "ALTLLM_WALLET_PRIVATE_KEY"): `0x${string}` {
-  const candidate = (explicit ?? process.env[envName] ?? "").trim();
-  if (!candidate) {
-    throw new CliError(`Private key missing. Provide --private-key or set ${envName}.`);
+function normalizePrivateKey(candidate: string): `0x${string}` {
+  const trimmed = candidate.trim();
+  if (!trimmed) {
+    throw new CliError("Private key cannot be empty.");
   }
 
-  const normalized = candidate.startsWith("0x") ? candidate : `0x${candidate}`;
+  const normalized = trimmed.startsWith("0x") ? trimmed : `0x${trimmed}`;
   if (!/^0x[a-fA-F0-9]{64}$/.test(normalized)) {
     throw new CliError("Private key must be a 32-byte hex string.");
   }
   return normalized as `0x${string}`;
+}
+
+export function validateUnsafePrivateKeyArgvUsage(params: {
+  explicit?: string;
+  allowUnsafeArgv?: boolean;
+}): void {
+  if (params.explicit !== undefined && !params.allowUnsafeArgv) {
+    throw new CliError(
+      "Refusing to read wallet private key directly from --private-key without --allow-unsafe-private-key-argv. Use --private-key-env or --private-key-file instead."
+    );
+  }
+}
+
+export async function resolvePrivateKey(params: {
+  explicit?: string;
+  filePath?: string;
+  envName?: string;
+  allowUnsafeArgv?: boolean;
+}): Promise<`0x${string}`> {
+  validateUnsafePrivateKeyArgvUsage({
+    explicit: params.explicit,
+    allowUnsafeArgv: params.allowUnsafeArgv,
+  });
+
+  const envName = params.envName || "ALTLLM_WALLET_PRIVATE_KEY";
+  const hasFilePath = params.filePath !== undefined;
+  const filePath = params.filePath?.trim() ?? "";
+
+  if (hasFilePath && !filePath) {
+    throw new CliError("--private-key-file cannot be empty.");
+  }
+
+  if (params.explicit !== undefined && hasFilePath) {
+    throw new CliError(
+      "Provide the wallet private key via only one source: --private-key, --private-key-file, or the selected environment variable."
+    );
+  }
+
+  if (params.explicit !== undefined) {
+    return normalizePrivateKey(params.explicit);
+  }
+
+  if (hasFilePath) {
+    const fileValue = await readFile(filePath, "utf8");
+    return normalizePrivateKey(fileValue);
+  }
+
+  const envValue = process.env[envName] ?? "";
+  if (!envValue.trim()) {
+    throw new CliError(
+      `Private key missing. Set ${envName} or provide --private-key-file.`
+    );
+  }
+
+  return normalizePrivateKey(envValue);
 }
 
 export function normalizeWalletSignature(signature: string): `0x${string}` {


### PR DESCRIPTION
## Summary
- add safer non-argv wallet private-key input paths for login and payment flows
- support `--private-key-file <path>` alongside the existing env-var path
- require `--allow-unsafe-private-key-argv` before honoring raw `--private-key` values
- document the safer input paths in the auth and payments references

## Testing
- `npm run typecheck`
- `npm run build`
- `node dist/cli.js login-wallet --base-url http://127.0.0.1:9 --wallet-address 0x1111111111111111111111111111111111111111 --private-key 1111111111111111111111111111111111111111111111111111111111111111`
- `node dist/cli.js pay-payment-link --base-url http://127.0.0.1:9 --payment-link-id dummy --private-key 1111111111111111111111111111111111111111111111111111111111111111`
- `tmp=$(mktemp) && printf '1111111111111111111111111111111111111111111111111111111111111111\n' > "$tmp" && node -e "import('./dist/lib/wallet.js').then(async (m) => { const key = await m.resolvePrivateKey({ filePath: process.argv[1] }); console.log(key); process.exit(key === '0x1111111111111111111111111111111111111111111111111111111111111111' ? 0 : 1); })" "$tmp"`
- `ALTLLM_WALLET_PRIVATE_KEY=1111111111111111111111111111111111111111111111111111111111111111 node -e "import('./dist/lib/wallet.js').then(async (m) => { const key = await m.resolvePrivateKey({ envName: 'ALTLLM_WALLET_PRIVATE_KEY' }); console.log(key); process.exit(key === '0x1111111111111111111111111111111111111111111111111111111111111111' ? 0 : 1); })"`

## Validation
- raw `--private-key` now fails locally unless `--allow-unsafe-private-key-argv` is also supplied
- `--private-key-file` and `--private-key-env` both resolve successfully

Closes #46.
