### PR TITLE
fix(urls): require https for non-local base URLs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,7 +44,7 @@ Default production API base URL:
 - `https://platform-api.altllm.ai`
 
 Do not change the default API base URL to localhost unless the task is explicitly about local development.
-Non-local Portal or Cloud Claw base URLs must use `https://`. Only loopback local-development targets may use `http://`.
+Commands that reuse a saved Portal session token, or forward that token to Cloud Claw, must use `https://` for non-local hosts. Pre-auth flows such as `login-wallet --prepare` are outside that guardrail.
 
 ## Repo Structure
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,7 @@ Default production API base URL:
 - `https://platform-api.altllm.ai`
 
 Do not change the default API base URL to localhost unless the task is explicitly about local development.
+Non-local Portal or Cloud Claw base URLs must use `https://`. Only loopback local-development targets may use `http://`.
 
 ## Repo Structure
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Production default:
 
 - `https://platform-api.altllm.ai`
 
-Only use localhost when you are explicitly testing local Portal APIs.
+Only use `http://` for explicit local-development loopback targets such as `http://localhost` or `http://127.0.0.1`. Non-local base URLs must use `https://`.
 
 If a command is reusing your saved Portal session token, the CLI will refuse to send that token to a different `--base-url` host unless you also pass `--allow-token-host-mismatch`.
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,9 @@ Production default:
 
 - `https://platform-api.altllm.ai`
 
-Only use `http://` for explicit local-development loopback targets such as `http://localhost` or `http://127.0.0.1`. Non-local base URLs must use `https://`.
+Only use `http://` for explicit local-development loopback targets such as `http://localhost` or `http://127.0.0.1`.
+
+Commands that reuse a saved Portal session token, or forward that token to Cloud Claw via `portal-sso`, require `https://` for non-local hosts. Pre-auth flows such as `login-wallet --prepare` do not reuse a saved session token and are not blocked by that HTTPS guardrail.
 
 If a command is reusing your saved Portal session token, the CLI will refuse to send that token to a different `--base-url` host unless you also pass `--allow-token-host-mismatch`.
 

--- a/skills/_shared/cloud-claw-preflight.md
+++ b/skills/_shared/cloud-claw-preflight.md
@@ -14,3 +14,4 @@ These notes apply when using the Cloud Claw skills from this repository.
 4. Assume Cloud Claw and AltLLM share session semantics. For scriptable user workflows, prefer `portal-sso` rather than re-describing the browser OAuth flow.
 5. Do not default to internal build/image scripts unless the user explicitly asks for infra maintenance.
 6. Do not forward the saved Portal session token to an arbitrary Cloud Claw host by default. If a non-trusted `--cloud-claw-base-url` is truly intended, require an explicit override such as `--allow-cloud-claw-token-forwarding`.
+7. Non-local Cloud Claw base URLs must use `https://`. Only loopback local-development targets should use `http://`.

--- a/skills/_shared/cloud-claw-preflight.md
+++ b/skills/_shared/cloud-claw-preflight.md
@@ -14,4 +14,4 @@ These notes apply when using the Cloud Claw skills from this repository.
 4. Assume Cloud Claw and AltLLM share session semantics. For scriptable user workflows, prefer `portal-sso` rather than re-describing the browser OAuth flow.
 5. Do not default to internal build/image scripts unless the user explicitly asks for infra maintenance.
 6. Do not forward the saved Portal session token to an arbitrary Cloud Claw host by default. If a non-trusted `--cloud-claw-base-url` is truly intended, require an explicit override such as `--allow-cloud-claw-token-forwarding`.
-7. Non-local Cloud Claw base URLs must use `https://`. Only loopback local-development targets should use `http://`.
+7. When forwarding the saved Portal session token to Cloud Claw, require `https://` for non-local `--cloud-claw-base-url` values. Only loopback local-development targets should use `http://`.

--- a/skills/_shared/preflight.md
+++ b/skills/_shared/preflight.md
@@ -5,7 +5,7 @@ Use these rules before the first `altllm` command in a fresh checkout or after c
 1. Default to the production Portal API:
    - `https://platform-api.altllm.ai`
    - Only use `http://localhost:7040` when the task is explicitly about local development.
-   - Non-local base URLs must use `https://`.
+   - Commands that reuse a saved Portal session token must use `https://` for non-local base URLs.
 2. Build the local CLI before first use in a fresh checkout:
    - `npm install`
    - `npm run typecheck` when TypeScript changed

--- a/skills/_shared/preflight.md
+++ b/skills/_shared/preflight.md
@@ -5,6 +5,7 @@ Use these rules before the first `altllm` command in a fresh checkout or after c
 1. Default to the production Portal API:
    - `https://platform-api.altllm.ai`
    - Only use `http://localhost:7040` when the task is explicitly about local development.
+   - Non-local base URLs must use `https://`.
 2. Build the local CLI before first use in a fresh checkout:
    - `npm install`
    - `npm run typecheck` when TypeScript changed

--- a/src/commands/login-wallet.ts
+++ b/src/commands/login-wallet.ts
@@ -256,6 +256,10 @@ function validateChallengeMessageForAutoSign(params: {
 export async function loginWallet(options: LoginWalletOptions): Promise<void> {
   const baseUrl = normalizeBaseUrl(options.baseUrl);
   const walletAddress = options.walletAddress.trim();
+  validateUnsafePrivateKeyArgvUsage({
+    explicit: options.privateKey,
+    allowUnsafeArgv: options.allowUnsafePrivateKeyArgv,
+  });
 
   normalizeWalletAddress(walletAddress);
 

--- a/src/commands/pay-payment-link.ts
+++ b/src/commands/pay-payment-link.ts
@@ -4,7 +4,11 @@ import {
   loadSession,
   resolveSessionBackedBaseUrl,
 } from "../lib/session.js";
-import { executeDirectPayment, resolvePrivateKey } from "../lib/wallet.js";
+import {
+  executeDirectPayment,
+  resolvePrivateKey,
+  validateUnsafePrivateKeyArgvUsage,
+} from "../lib/wallet.js";
 import {
   fetchPaymentLinkStatus,
   formatPaymentLinkRecord,
@@ -28,6 +32,11 @@ export interface PayPaymentLinkOptions {
 }
 
 export async function payPaymentLink(options: PayPaymentLinkOptions): Promise<void> {
+  validateUnsafePrivateKeyArgvUsage({
+    explicit: options.privateKey,
+    allowUnsafeArgv: options.allowUnsafePrivateKeyArgv,
+  });
+
   if (options.wait) {
     validatePaymentPollingOptions({
       pollIntervalSeconds: options.pollIntervalSeconds,

--- a/src/commands/topup-crypto.ts
+++ b/src/commands/topup-crypto.ts
@@ -4,7 +4,11 @@ import {
   loadSession,
   resolveSessionBackedBaseUrl,
 } from "../lib/session.js";
-import { executeDirectPayment, resolvePrivateKey } from "../lib/wallet.js";
+import {
+  executeDirectPayment,
+  resolvePrivateKey,
+  validateUnsafePrivateKeyArgvUsage,
+} from "../lib/wallet.js";
 
 export interface TopupCryptoOptions {
   amount: number;
@@ -177,6 +181,11 @@ export async function topupCrypto(options: TopupCryptoOptions): Promise<void> {
   if (!Number.isFinite(options.amount) || options.amount < 0.5) {
     throw new CliError("Amount must be >= 0.5 USD.");
   }
+
+  validateUnsafePrivateKeyArgvUsage({
+    explicit: options.privateKey,
+    allowUnsafeArgv: options.allowUnsafePrivateKeyArgv,
+  });
 
   if (options.wait) {
     validatePaymentPollingOptions({

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -8,7 +8,33 @@ export class CliError extends Error {
 const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
 
 export function normalizeBaseUrl(baseUrl: string): string {
-  return baseUrl.replace(/\/+$/, "");
+  const normalized = baseUrl.replace(/\/+$/, "");
+
+  let parsed: URL;
+  try {
+    parsed = new URL(normalized);
+  } catch {
+    throw new CliError(`Invalid base URL: ${baseUrl}`);
+  }
+
+  const protocol = parsed.protocol.toLowerCase();
+  const hostname = parsed.hostname.toLowerCase();
+  const isLoopbackHost =
+    hostname === "localhost" ||
+    hostname === "::1" ||
+    /^127(?:\.\d{1,3}){3}$/.test(hostname);
+
+  if (protocol === "https:") {
+    return normalized;
+  }
+
+  if (protocol === "http:" && isLoopbackHost) {
+    return normalized;
+  }
+
+  throw new CliError(
+    `Insecure base URL not allowed for non-local hosts: ${normalized}. Use https:// for non-local targets.`
+  );
 }
 
 export function canonicalizeOrigin(baseUrl: string): string {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -7,22 +7,40 @@ export class CliError extends Error {
 
 const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
 
-export function normalizeBaseUrl(baseUrl: string): string {
-  const normalized = baseUrl.replace(/\/+$/, "");
-
+function parseBaseUrl(baseUrl: string): URL {
   let parsed: URL;
   try {
-    parsed = new URL(normalized);
+    parsed = new URL(baseUrl);
   } catch {
     throw new CliError(`Invalid base URL: ${baseUrl}`);
   }
 
+  return parsed;
+}
+
+function isLoopbackHostname(hostname: string): boolean {
+  const normalizedHostname = hostname.toLowerCase();
+  return (
+    normalizedHostname === "localhost" ||
+    normalizedHostname === "::1" ||
+    /^127(?:\.\d{1,3}){3}$/.test(normalizedHostname)
+  );
+}
+
+export function normalizeBaseUrl(baseUrl: string): string {
+  const normalized = baseUrl.replace(/\/+$/, "");
+  parseBaseUrl(normalized);
+  return normalized;
+}
+
+export function requireSecureNonLocalBaseUrl(
+  baseUrl: string,
+  credentialDescription: string
+): string {
+  const normalized = normalizeBaseUrl(baseUrl);
+  const parsed = parseBaseUrl(normalized);
   const protocol = parsed.protocol.toLowerCase();
-  const hostname = parsed.hostname.toLowerCase();
-  const isLoopbackHost =
-    hostname === "localhost" ||
-    hostname === "::1" ||
-    /^127(?:\.\d{1,3}){3}$/.test(hostname);
+  const isLoopbackHost = isLoopbackHostname(parsed.hostname);
 
   if (protocol === "https:") {
     return normalized;
@@ -33,7 +51,7 @@ export function normalizeBaseUrl(baseUrl: string): string {
   }
 
   throw new CliError(
-    `Insecure base URL not allowed for non-local hosts: ${normalized}. Use https:// for non-local targets.`
+    `Refusing to send ${credentialDescription} to insecure non-local base URL ${normalized}. Use https:// for non-local targets.`
   );
 }
 

--- a/src/lib/cloud-claw.ts
+++ b/src/lib/cloud-claw.ts
@@ -3,6 +3,7 @@ import {
   CliError,
   normalizeBaseUrl,
   requestJson,
+  requireSecureNonLocalBaseUrl,
 } from "./api.js";
 import { DEFAULT_SESSION_FILE, loadSession } from "./session.js";
 
@@ -22,6 +23,10 @@ function ensureCloudClawBaseUrlAllowed(params: {
   allowTokenForwarding?: boolean;
 }): void {
   const normalizedBaseUrl = normalizeCloudClawBaseUrl(params.baseUrl);
+  requireSecureNonLocalBaseUrl(
+    normalizedBaseUrl,
+    "the saved Portal session token"
+  );
   const normalizedTrustedBaseUrl = normalizeCloudClawBaseUrl(
     TRUSTED_CLOUD_CLAW_BASE_URL
   );

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -2,7 +2,12 @@ import { chmod, mkdir, readFile, unlink, writeFile } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 import { homedir } from "node:os";
 
-import { canonicalizeOrigin, CliError, normalizeBaseUrl } from "./api.js";
+import {
+  canonicalizeOrigin,
+  CliError,
+  normalizeBaseUrl,
+  requireSecureNonLocalBaseUrl,
+} from "./api.js";
 
 export interface PortalSession {
   baseUrl: string;
@@ -51,6 +56,10 @@ export function resolveSessionBackedBaseUrl(params: {
   const normalizedSessionBaseUrl = normalizeBaseUrl(params.sessionBaseUrl);
   const normalizedBaseUrl = normalizeBaseUrl(
     params.baseUrl || params.sessionBaseUrl
+  );
+  requireSecureNonLocalBaseUrl(
+    normalizedBaseUrl,
+    "the saved Portal session token"
   );
   const canonicalSessionOrigin = canonicalizeOrigin(normalizedSessionBaseUrl);
   const canonicalRequestedOrigin = canonicalizeOrigin(normalizedBaseUrl);


### PR DESCRIPTION
## Summary
- require `https://` for non-local Portal and Cloud Claw base URLs
- continue allowing `http://` for explicit loopback/local-development targets such as `localhost`, `127.0.0.1`, and `::1`
- enforce the policy centrally in `normalizeBaseUrl()` so both Portal and Cloud Claw command paths inherit it
- align README, AGENTS, and shared preflight docs with the runtime behavior

## Testing
- `npm run typecheck`
- `npm run build`
- `node -e "import('./dist/lib/api.js').then((m) => { try { console.log(m.normalizeBaseUrl('https://platform-api.altllm.ai')); console.log(m.normalizeBaseUrl('http://127.0.0.1:7040')); try { m.normalizeBaseUrl('http://example.com'); process.exit(1); } catch (error) { const message = error instanceof Error ? error.message : String(error); console.log(message); process.exit(message.includes('Insecure base URL not allowed for non-local hosts') ? 0 : 1); } } catch (error) { console.error(error instanceof Error ? error.message : String(error)); process.exit(1); } })"`
- `node dist/cli.js login-wallet --base-url http://example.com --wallet-address 0x1111111111111111111111111111111111111111 --prepare`
- `tmp=$(mktemp) && printf '{"baseUrl":"https://platform-api.altllm.ai","token":"FAKE_PORTAL_TOKEN","user":{"id":"u","email":"u@example.com"}}' > "$tmp" && node dist/cli.js credit --session-file "$tmp" --base-url http://example.com --allow-token-host-mismatch`
- `tmp=$(mktemp) && printf '{"baseUrl":"https://platform-api.altllm.ai","token":"FAKE_PORTAL_TOKEN","user":{"id":"u","email":"u@example.com"}}' > "$tmp" && node dist/cli.js cloud-claw-me --session-file "$tmp" --cloud-claw-base-url http://example.com --allow-cloud-claw-token-forwarding`

Closes #47.
