### PR TITLE
fix(auth): handle stale saved portal sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,16 @@ Successful login stores a session at:
 
 On POSIX systems, the CLI saves the session directory and file with private permissions (`0700` for the directory and `0600` for the file).
 
+After the AltLLM Portal session trust-domain rollout, sessions created before the rollout may be rejected by Portal API routes or Cloud Claw `portal-sso`. When that happens, saved-session commands fail with a direct re-login instruction instead of a raw endpoint error:
+
+```bash
+node dist/cli.js login-wallet \
+  --base-url https://platform-api.altllm.ai \
+  --wallet-address 0x...
+```
+
+The CLI does not delete the existing session file automatically. `login-wallet` replaces it after a successful login, or you can remove it explicitly with `logout`.
+
 Remove the local Portal session:
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "dev": "tsx src/cli.ts",
-    "test": "npm run build && node --test tests/*.test.mjs",
+    "test": "npm run build && node --test tests/*.test.mjs && node --import tsx --test test/**/*.test.ts",
     "typecheck": "tsc --noEmit"
   },
   "repository": {

--- a/skills/_shared/session-and-target.md
+++ b/skills/_shared/session-and-target.md
@@ -3,5 +3,7 @@
 - This repository targets the AltLLM Portal API, not the OpenAI-compatible gateway.
 - Use the saved Portal session for follow-up commands unless the user overrides `--session-file`.
 - The default session file is `~/.altllm/portal-cli-session.json`.
+- After the Portal session trust-domain rollout, pre-rollout saved sessions may be rejected by Portal API routes or Cloud Claw `portal-sso`; run `altllm login-wallet` again to refresh the saved session.
+- Stale-session errors should not delete the local session file implicitly. Use `altllm logout` when explicit removal is desired.
 - API keys created through Portal are meant for the AltLLM OpenAI-compatible gateway at `https://api.altllm.ai/v1`.
 - Current wallet login still requires an EVM address and Ethereum-style signature verification on the backend.

--- a/skills/altllm-portal-auth/SKILL.md
+++ b/skills/altllm-portal-auth/SKILL.md
@@ -33,6 +33,7 @@ user-invocable: true
 - For non-default, non-loopback API hosts, prefer `--prepare` and external signing instead of local auto-signing.
 - Current backend support is still limited to EVM addresses and Ethereum-style signatures.
 - Save the resulting session to `~/.altllm/portal-cli-session.json` unless overridden.
+- If saved-session commands report that the Portal session was rejected after the trust-domain rollout, run `login-wallet` again to refresh the session.
 - `logout` only removes the local session file. It does not revoke API keys.
 
 ## Reference

--- a/src/commands/create-api-key.ts
+++ b/src/commands/create-api-key.ts
@@ -1,4 +1,4 @@
-import { requestJson } from "../lib/api.js";
+import { requestSavedPortalSessionJson } from "../lib/api.js";
 import {
   buildKeyPermissions,
   CreateKeyResponse,
@@ -30,7 +30,7 @@ export async function createApiKey(options: CreateApiKeyOptions): Promise<void> 
     allowTokenHostMismatch: options.allowTokenHostMismatch,
   });
 
-  const result = await requestJson<CreateKeyResponse>({
+  const result = await requestSavedPortalSessionJson<CreateKeyResponse>({
     method: "POST",
     url: `${baseUrl}/api/keys`,
     token,

--- a/src/commands/credit.ts
+++ b/src/commands/credit.ts
@@ -1,4 +1,4 @@
-import { normalizeBaseUrl, requestJson } from "../lib/api.js";
+import { normalizeBaseUrl, requestSavedPortalSessionJson } from "../lib/api.js";
 import {
   DEFAULT_SESSION_FILE,
   loadSession,
@@ -21,7 +21,7 @@ export async function credit(options: CreditOptions): Promise<void> {
     })
   );
 
-  const result = await requestJson<Record<string, unknown>>({
+  const result = await requestSavedPortalSessionJson<Record<string, unknown>>({
     method: "GET",
     url: `${baseUrl}/api/billing/balance`,
     token: session.token,

--- a/src/commands/get-api-key.ts
+++ b/src/commands/get-api-key.ts
@@ -1,4 +1,4 @@
-import { requestJson } from "../lib/api.js";
+import { requestSavedPortalSessionJson } from "../lib/api.js";
 import { KeyDetail, resolvePortalContext, writeJson } from "../lib/keys.js";
 import { DEFAULT_SESSION_FILE } from "../lib/session.js";
 
@@ -16,7 +16,7 @@ export async function getApiKey(options: GetApiKeyOptions): Promise<void> {
     allowTokenHostMismatch: options.allowTokenHostMismatch,
   });
 
-  const result = await requestJson<KeyDetail>({
+  const result = await requestSavedPortalSessionJson<KeyDetail>({
     method: "GET",
     url: `${baseUrl}/api/keys/${options.keyId}`,
     token,

--- a/src/commands/list-api-keys.ts
+++ b/src/commands/list-api-keys.ts
@@ -1,4 +1,4 @@
-import { requestJson } from "../lib/api.js";
+import { requestSavedPortalSessionJson } from "../lib/api.js";
 import { ListKeysResponse, resolvePortalContext, writeJson } from "../lib/keys.js";
 import { DEFAULT_SESSION_FILE } from "../lib/session.js";
 
@@ -15,7 +15,7 @@ export async function listApiKeys(options: ListApiKeysOptions): Promise<void> {
     allowTokenHostMismatch: options.allowTokenHostMismatch,
   });
 
-  const result = await requestJson<ListKeysResponse>({
+  const result = await requestSavedPortalSessionJson<ListKeysResponse>({
     method: "GET",
     url: `${baseUrl}/api/keys`,
     token,

--- a/src/commands/redeem-promo.ts
+++ b/src/commands/redeem-promo.ts
@@ -1,4 +1,4 @@
-import { normalizeBaseUrl, requestJson } from "../lib/api.js";
+import { normalizeBaseUrl, requestSavedPortalSessionJson } from "../lib/api.js";
 import {
   DEFAULT_SESSION_FILE,
   loadSession,
@@ -22,7 +22,7 @@ export async function redeemPromo(options: RedeemPromoOptions): Promise<void> {
     })
   );
 
-  const result = await requestJson<Record<string, unknown>>({
+  const result = await requestSavedPortalSessionJson<Record<string, unknown>>({
     method: "POST",
     url: `${baseUrl}/api/billing/redeem-promo`,
     token: session.token,

--- a/src/commands/revoke-api-key.ts
+++ b/src/commands/revoke-api-key.ts
@@ -1,4 +1,4 @@
-import { requestJson } from "../lib/api.js";
+import { requestSavedPortalSessionJson } from "../lib/api.js";
 import {
   KeyDeletedResponse,
   resolvePortalContext,
@@ -20,7 +20,7 @@ export async function revokeApiKey(options: RevokeApiKeyOptions): Promise<void> 
     allowTokenHostMismatch: options.allowTokenHostMismatch,
   });
 
-  const result = await requestJson<KeyDeletedResponse>({
+  const result = await requestSavedPortalSessionJson<KeyDeletedResponse>({
     method: "DELETE",
     url: `${baseUrl}/api/keys/${options.keyId}`,
     token,

--- a/src/commands/topup-crypto.ts
+++ b/src/commands/topup-crypto.ts
@@ -1,4 +1,8 @@
-import { CliError, normalizeBaseUrl, requestJson } from "../lib/api.js";
+import {
+  CliError,
+  normalizeBaseUrl,
+  requestSavedPortalSessionJson,
+} from "../lib/api.js";
 import {
   DEFAULT_SESSION_FILE,
   loadSession,
@@ -85,7 +89,7 @@ export async function fetchPaymentLinkStatus(
   token: string,
   paymentLinkId: string
 ): Promise<PaymentLinkRecord> {
-  const payload = await requestJson<PaymentLinksResponse>({
+  const payload = await requestSavedPortalSessionJson<PaymentLinksResponse>({
     method: "GET",
     url: `${baseUrl}/api/billing/payment-links?limit=${PAYMENT_LINK_LOOKUP_LIMIT}`,
     token,
@@ -203,7 +207,7 @@ export async function topupCrypto(options: TopupCryptoOptions): Promise<void> {
     })
   );
 
-  const created = await requestJson<CreatePaymentLinkResponse>({
+  const created = await requestSavedPortalSessionJson<CreatePaymentLinkResponse>({
     method: "POST",
     url: `${baseUrl}/api/billing/payment-link`,
     token: session.token,

--- a/src/commands/transactions.ts
+++ b/src/commands/transactions.ts
@@ -1,4 +1,4 @@
-import { requestJson } from "../lib/api.js";
+import { requestSavedPortalSessionJson } from "../lib/api.js";
 import {
   appendPaginationParams,
   parseTransactionFilterType,
@@ -33,7 +33,7 @@ export async function transactions(options: TransactionsOptions): Promise<void> 
   }
 
   const suffix = searchParams.size > 0 ? `?${searchParams.toString()}` : "";
-  const result = await requestJson<Record<string, unknown>>({
+  const result = await requestSavedPortalSessionJson<Record<string, unknown>>({
     method: "GET",
     url: `${baseUrl}/api/billing/transactions${suffix}`,
     token,

--- a/src/commands/update-api-key.ts
+++ b/src/commands/update-api-key.ts
@@ -1,4 +1,4 @@
-import { CliError, requestJson } from "../lib/api.js";
+import { CliError, requestSavedPortalSessionJson } from "../lib/api.js";
 import {
   buildKeyPermissions,
   KeyDetail,
@@ -55,7 +55,7 @@ export async function updateApiKey(options: UpdateApiKeyOptions): Promise<void> 
     allowTokenHostMismatch: options.allowTokenHostMismatch,
   });
 
-  const result = await requestJson<KeyDetail>({
+  const result = await requestSavedPortalSessionJson<KeyDetail>({
     method: "PATCH",
     url: `${baseUrl}/api/keys/${options.keyId}`,
     token,

--- a/src/commands/usage-by-key.ts
+++ b/src/commands/usage-by-key.ts
@@ -1,4 +1,4 @@
-import { requestJson } from "../lib/api.js";
+import { requestSavedPortalSessionJson } from "../lib/api.js";
 import { appendRequiredDateRangeParams } from "../lib/history.js";
 import { resolvePortalContext, writeJson } from "../lib/keys.js";
 import { DEFAULT_SESSION_FILE } from "../lib/session.js";
@@ -25,7 +25,7 @@ export async function usageByKey(options: UsageByKeyOptions): Promise<void> {
   });
 
   const suffix = searchParams.size > 0 ? `?${searchParams.toString()}` : "";
-  const result = await requestJson<Record<string, unknown>>({
+  const result = await requestSavedPortalSessionJson<Record<string, unknown>>({
     method: "GET",
     url: `${baseUrl}/api/usage/by-key${suffix}`,
     token,

--- a/src/commands/usage-by-model.ts
+++ b/src/commands/usage-by-model.ts
@@ -1,4 +1,4 @@
-import { requestJson } from "../lib/api.js";
+import { requestSavedPortalSessionJson } from "../lib/api.js";
 import { appendMonthOrDateRangeParams } from "../lib/history.js";
 import { resolvePortalContext, writeJson } from "../lib/keys.js";
 import { DEFAULT_SESSION_FILE } from "../lib/session.js";
@@ -27,7 +27,7 @@ export async function usageByModel(options: UsageByModelOptions): Promise<void> 
   });
 
   const suffix = searchParams.size > 0 ? `?${searchParams.toString()}` : "";
-  const result = await requestJson<Record<string, unknown>>({
+  const result = await requestSavedPortalSessionJson<Record<string, unknown>>({
     method: "GET",
     url: `${baseUrl}/api/usage/by-model${suffix}`,
     token,

--- a/src/commands/usage-summary.ts
+++ b/src/commands/usage-summary.ts
@@ -1,4 +1,4 @@
-import { requestJson } from "../lib/api.js";
+import { requestSavedPortalSessionJson } from "../lib/api.js";
 import { resolvePortalContext, writeJson } from "../lib/keys.js";
 import { DEFAULT_SESSION_FILE } from "../lib/session.js";
 
@@ -15,7 +15,7 @@ export async function usageSummary(options: UsageSummaryOptions): Promise<void> 
     allowTokenHostMismatch: options.allowTokenHostMismatch,
   });
 
-  const result = await requestJson<Record<string, unknown>>({
+  const result = await requestSavedPortalSessionJson<Record<string, unknown>>({
     method: "GET",
     url: `${baseUrl}/api/usage/summary`,
     token,

--- a/src/commands/usage-timeline.ts
+++ b/src/commands/usage-timeline.ts
@@ -1,4 +1,4 @@
-import { requestJson } from "../lib/api.js";
+import { requestSavedPortalSessionJson } from "../lib/api.js";
 import { appendMonthOrDateRangeParams } from "../lib/history.js";
 import { resolvePortalContext, writeJson } from "../lib/keys.js";
 import { DEFAULT_SESSION_FILE } from "../lib/session.js";
@@ -27,7 +27,7 @@ export async function usageTimeline(options: UsageTimelineOptions): Promise<void
   });
 
   const suffix = searchParams.size > 0 ? `?${searchParams.toString()}` : "";
-  const result = await requestJson<Record<string, unknown>>({
+  const result = await requestSavedPortalSessionJson<Record<string, unknown>>({
     method: "GET",
     url: `${baseUrl}/api/usage/timeline${suffix}`,
     token,

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -6,6 +6,33 @@ export class CliError extends Error {
 }
 
 const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
+const SAVED_PORTAL_SESSION_RELOGIN_MESSAGE =
+  "Run altllm login-wallet again to refresh the saved Portal session, then retry this command.";
+
+interface RequestJsonOptions {
+  method: string;
+  url: string;
+  body?: unknown;
+  token?: string;
+  headers?: Record<string, string>;
+  savedPortalSession?: boolean;
+}
+
+function isAuthFailureStatus(status: number): boolean {
+  return status === 401 || status === 403;
+}
+
+function formatSavedPortalSessionAuthFailure(params: {
+  method: string;
+  url: string;
+  status: number;
+}): string {
+  return (
+    `Saved Portal session was rejected by ${params.method} ${params.url} (${params.status}). ` +
+    "This can happen if the session expired or was created before the AltLLM Portal session trust-domain rollout. " +
+    `${SAVED_PORTAL_SESSION_RELOGIN_MESSAGE} The session file was not deleted.`
+  );
+}
 
 function parseBaseUrl(baseUrl: string): URL {
   let parsed: URL;
@@ -131,13 +158,8 @@ export async function requestJson<T>({
   body,
   token,
   headers: extraHeaders,
-}: {
-  method: string;
-  url: string;
-  body?: unknown;
-  token?: string;
-  headers?: Record<string, string>;
-}): Promise<T> {
+  savedPortalSession,
+}: RequestJsonOptions): Promise<T> {
   const headers: Record<string, string> = {
     Accept: "application/json",
     ...extraHeaders,
@@ -162,6 +184,16 @@ export async function requestJson<T>({
   const text = await response.text();
 
   if (!response.ok) {
+    if (savedPortalSession && isAuthFailureStatus(response.status)) {
+      throw new CliError(
+        formatSavedPortalSessionAuthFailure({
+          method,
+          url,
+          status: response.status,
+        })
+      );
+    }
+
     throw new CliError(`${method} ${url} failed: ${response.status} ${text}`);
   }
 
@@ -174,4 +206,13 @@ export async function requestJson<T>({
   } catch {
     throw new CliError(`${method} ${url} returned invalid JSON: ${text}`);
   }
+}
+
+export async function requestSavedPortalSessionJson<T>(
+  params: Omit<RequestJsonOptions, "savedPortalSession">
+): Promise<T> {
+  return requestJson<T>({
+    ...params,
+    savedPortalSession: true,
+  });
 }

--- a/src/lib/cloud-claw.ts
+++ b/src/lib/cloud-claw.ts
@@ -3,6 +3,7 @@ import {
   CliError,
   normalizeBaseUrl,
   requestJson,
+  requestSavedPortalSessionJson,
   requireSecureNonLocalBaseUrl,
 } from "./api.js";
 import { DEFAULT_SESSION_FILE, loadSession } from "./session.js";
@@ -59,7 +60,10 @@ export async function getCloudClawJwt(params: {
 
   const session = await loadSession(params.sessionFile || DEFAULT_SESSION_FILE);
 
-  const sso = await requestJson<{ authenticated?: boolean; token?: string }>({
+  const sso = await requestSavedPortalSessionJson<{
+    authenticated?: boolean;
+    token?: string;
+  }>({
     method: "POST",
     url: `${baseUrl}/api/auth/portal-sso`,
     body: {

--- a/test/session-rollout.test.ts
+++ b/test/session-rollout.test.ts
@@ -1,0 +1,183 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test, { afterEach } from "node:test";
+
+import { credit } from "../src/commands/credit.js";
+import { getCloudClawJwt } from "../src/lib/cloud-claw.js";
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+async function withTempDir<T>(fn: (dir: string) => Promise<T>): Promise<T> {
+  const dir = await mkdtemp(join(tmpdir(), "altllm-session-rollout-"));
+  try {
+    return await fn(dir);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+async function writeSessionFile(params: {
+  dir: string;
+  baseUrl: string;
+  token?: string;
+}): Promise<string> {
+  const sessionFile = join(params.dir, "portal-cli-session.json");
+  await writeFile(
+    sessionFile,
+    JSON.stringify(
+      {
+        baseUrl: params.baseUrl,
+        token: params.token ?? "pre-rollout-token",
+        user: {
+          id: "user_123",
+          email: "user@example.com",
+          name: null,
+        },
+      },
+      null,
+      2
+    ),
+    "utf8"
+  );
+  return sessionFile;
+}
+
+function mockFetch(
+  handler: (params: {
+    url: string;
+    init?: RequestInit;
+  }) => Response | Promise<Response>
+): void {
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url =
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : input.url;
+    return handler({ url, init });
+  }) as typeof fetch;
+}
+
+async function captureStdout(fn: () => Promise<void>): Promise<string> {
+  const chunks: string[] = [];
+  const originalWrite = process.stdout.write;
+  process.stdout.write = ((chunk: unknown, ...args: unknown[]) => {
+    chunks.push(String(chunk));
+    const callback = args.find((arg): arg is () => void => typeof arg === "function");
+    callback?.();
+    return true;
+  }) as typeof process.stdout.write;
+
+  try {
+    await fn();
+    return chunks.join("");
+  } finally {
+    process.stdout.write = originalWrite;
+  }
+}
+
+function assertReloginError(error: unknown): boolean {
+  assert(error instanceof Error);
+  assert.match(error.message, /Saved Portal session was rejected/);
+  assert.match(error.message, /trust-domain rollout/);
+  assert.match(error.message, /Run altllm login-wallet again/);
+  assert.match(error.message, /session file was not deleted/);
+  assert.doesNotMatch(error.message, /failed: 401/);
+  assert.doesNotMatch(error.message, /failed: 403/);
+  return true;
+}
+
+test("Portal API saved-session 401 returns a clear re-login error", async () => {
+  await withTempDir(async (dir) => {
+    const baseUrl = "http://127.0.0.1:7040";
+    const sessionFile = await writeSessionFile({ dir, baseUrl });
+
+    mockFetch(({ url, init }) => {
+      assert.equal(url, `${baseUrl}/api/billing/balance`);
+      assert.equal(init?.headers instanceof Headers, false);
+      assert.equal(
+        (init?.headers as Record<string, string>).Authorization,
+        "Bearer pre-rollout-token"
+      );
+      return new Response(JSON.stringify({ error: "invalid token" }), {
+        status: 401,
+      });
+    });
+
+    await assert.rejects(
+      () => credit({ baseUrl, sessionFile }),
+      assertReloginError
+    );
+
+    const persistedSession = JSON.parse(await readFile(sessionFile, "utf8")) as {
+      token: string;
+    };
+    assert.equal(persistedSession.token, "pre-rollout-token");
+  });
+});
+
+test("Cloud Claw portal-sso 403 returns the saved-session re-login error", async () => {
+  await withTempDir(async (dir) => {
+    const sessionFile = await writeSessionFile({
+      dir,
+      baseUrl: "https://platform-api.altllm.ai",
+    });
+    const cloudClawBaseUrl = "http://127.0.0.1:7041";
+
+    mockFetch(async ({ url, init }) => {
+      assert.equal(url, `${cloudClawBaseUrl}/api/auth/portal-sso`);
+      assert.deepEqual(JSON.parse(String(init?.body)), {
+        token: "pre-rollout-token",
+        force: false,
+      });
+      return new Response(JSON.stringify({ error: "portal token rejected" }), {
+        status: 403,
+      });
+    });
+
+    await assert.rejects(
+      () =>
+        getCloudClawJwt({
+          baseUrl: cloudClawBaseUrl,
+          sessionFile,
+          allowTokenForwarding: true,
+        }),
+      assertReloginError
+    );
+  });
+});
+
+test("valid saved sessions continue to return command JSON", async () => {
+  await withTempDir(async (dir) => {
+    const baseUrl = "http://127.0.0.1:7040";
+    const sessionFile = await writeSessionFile({ dir, baseUrl, token: "valid-token" });
+
+    mockFetch(({ url, init }) => {
+      assert.equal(url, `${baseUrl}/api/billing/balance`);
+      assert.equal(
+        (init?.headers as Record<string, string>).Authorization,
+        "Bearer valid-token"
+      );
+      return new Response(
+        JSON.stringify({
+          balance: 12.5,
+          currency: "USD",
+        }),
+        { status: 200 }
+      );
+    });
+
+    const stdout = await captureStdout(() => credit({ baseUrl, sessionFile }));
+    assert.deepEqual(JSON.parse(stdout), {
+      balance: 12.5,
+      currency: "USD",
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- map saved Portal session 401/403 responses to a clear re-login instruction
- apply the same stale-session handling to Cloud Claw portal-sso failures
- add mocked regression coverage plus rollout docs for the one-time re-login requirement
- include the missing login-wallet wallet-helper import needed for local verification

## Tests
- npm install
- npm run typecheck
- npm run build
- npm test
- node dist/cli.js --help
- node dist/cli.js cloud-claw-me --help
- mocked built-CLI smoke for Portal 401 and Cloud Claw portal-sso 403

Closes #61