### PR TITLE
fix(cloud-claw): normalize auth rollout failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,8 @@ node dist/cli.js cloud-claw-me
 
 If you intentionally point Cloud Claw commands at a non-trusted host with `--cloud-claw-base-url`, also pass `--allow-cloud-claw-token-forwarding`. Without that explicit override, the CLI will refuse to POST your saved Portal session token to that host.
 
+During the security-rollup transition, Cloud Claw auth failures are normalized before they reach the user. A `401` or `403` from `portal-sso` means the saved Portal session was rejected; run `altllm login-wallet` again and retry. A `503` from `portal-sso` points to Portal or Cloud Claw auth availability or rollout configuration. A `401` from VM or log routes means the Cloud Claw session JWT was rejected, while a `403` means the account is not authorized for that resource or action. Non-auth server failures still include the HTTP status and backend detail for debugging.
+
 List deployments:
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "dev": "tsx src/cli.ts",
-    "test": "npm run build && node --test tests/*.test.mjs && node --import tsx --test test/**/*.test.ts",
+    "test": "npm run build && node --test tests/*.test.mjs && node --import tsx --test test/**/*.test.ts tests/*.test.ts",
     "typecheck": "tsc --noEmit"
   },
   "repository": {

--- a/skills/_shared/cloud-claw-preflight.md
+++ b/skills/_shared/cloud-claw-preflight.md
@@ -15,3 +15,4 @@ These notes apply when using the Cloud Claw skills from this repository.
 5. Do not default to internal build/image scripts unless the user explicitly asks for infra maintenance.
 6. Do not forward the saved Portal session token to an arbitrary Cloud Claw host by default. If a non-trusted `--cloud-claw-base-url` is truly intended, require an explicit override such as `--allow-cloud-claw-token-forwarding`.
 7. When forwarding the saved Portal session token to Cloud Claw, require `https://` for non-local `--cloud-claw-base-url` values. Only loopback local-development targets should use `http://`.
+8. During auth/security rollouts, interpret `portal-sso` `401`/`403` as saved Portal session rejection and ask the user to run `altllm login-wallet` again. Treat `portal-sso` `503` as Portal or Cloud Claw auth availability/configuration risk. Treat Cloud Claw VM/log `401` as JWT rejection and `403` as account/resource authorization denial.

--- a/src/commands/cloud-claw-logs.ts
+++ b/src/commands/cloud-claw-logs.ts
@@ -1,5 +1,10 @@
 import { CliError, fetchWithTimeout, normalizeBaseUrl } from "../lib/api.js";
-import { DEFAULT_CLOUD_CLAW_BASE_URL, getCloudClawJwt, validateDeploymentName } from "../lib/cloud-claw.js";
+import {
+  DEFAULT_CLOUD_CLAW_BASE_URL,
+  formatCloudClawHttpError,
+  getCloudClawJwt,
+  validateDeploymentName,
+} from "../lib/cloud-claw.js";
 import { DEFAULT_SESSION_FILE } from "../lib/session.js";
 
 export interface CloudClawLogsOptions {
@@ -21,9 +26,10 @@ export async function cloudClawLogs(options: CloudClawLogsOptions): Promise<void
   });
 
   if (!options.stream) {
+    const url = `${normalizeBaseUrl(baseUrl)}/api/vm/deployments/${name}/logs`;
     const response = await fetchWithTimeout({
       method: "GET",
-      url: `${normalizeBaseUrl(baseUrl)}/api/vm/deployments/${name}/logs`,
+      url,
       headers: {
         Accept: "application/json",
         Authorization: `Bearer ${jwt}`,
@@ -31,26 +37,42 @@ export async function cloudClawLogs(options: CloudClawLogsOptions): Promise<void
     });
     const text = await response.text();
     if (!response.ok) {
-      throw new CliError(`GET ${baseUrl}/api/vm/deployments/${name}/logs failed: ${response.status} ${text}`);
+      throw new CliError(
+        formatCloudClawHttpError({
+          surface: "logs",
+          method: "GET",
+          url,
+          status: response.status,
+          text,
+          operation: `GET /api/vm/deployments/${name}/logs`,
+        })
+      );
     }
     process.stdout.write(text.endsWith("\n") ? text : `${text}\n`);
     return;
   }
 
-  const response = await fetch(
-    `${normalizeBaseUrl(baseUrl)}/api/vm/deployments/${name}/logs/stream`,
-    {
-      headers: {
-        Accept: "text/event-stream",
-        Authorization: `Bearer ${jwt}`,
-      },
-    }
-  );
+  const streamUrl = `${normalizeBaseUrl(
+    baseUrl
+  )}/api/vm/deployments/${name}/logs/stream`;
+  const response = await fetch(streamUrl, {
+    headers: {
+      Accept: "text/event-stream",
+      Authorization: `Bearer ${jwt}`,
+    },
+  });
 
   if (!response.ok || !response.body) {
     const text = await response.text();
     throw new CliError(
-      `GET ${baseUrl}/api/vm/deployments/${name}/logs/stream failed: ${response.status} ${text}`
+      formatCloudClawHttpError({
+        surface: "log-stream",
+        method: "GET",
+        url: streamUrl,
+        status: response.status,
+        text,
+        operation: `GET /api/vm/deployments/${name}/logs/stream`,
+      })
     );
   }
 

--- a/src/lib/cloud-claw.ts
+++ b/src/lib/cloud-claw.ts
@@ -1,9 +1,8 @@
 import {
   canonicalizeOrigin,
   CliError,
+  fetchWithTimeout,
   normalizeBaseUrl,
-  requestJson,
-  requestSavedPortalSessionJson,
   requireSecureNonLocalBaseUrl,
 } from "./api.js";
 import { DEFAULT_SESSION_FILE, loadSession } from "./session.js";
@@ -14,6 +13,105 @@ export const DEFAULT_CLOUD_CLAW_BASE_URL =
 
 export const CLOUD_CLAW_AGENT_TYPES = ["openclaw", "picoclaw", "aintern"] as const;
 export type CloudClawAgentType = (typeof CLOUD_CLAW_AGENT_TYPES)[number];
+
+export type CloudClawHttpSurface =
+  | "portal-sso"
+  | "api"
+  | "logs"
+  | "log-stream";
+
+function extractCloudClawErrorDetail(text: string): string {
+  const trimmed = text.trim();
+  if (!trimmed) {
+    return "";
+  }
+
+  try {
+    const parsed = JSON.parse(trimmed) as unknown;
+
+    if (typeof parsed === "string") {
+      return parsed.trim();
+    }
+
+    if (typeof parsed === "object" && parsed !== null) {
+      const record = parsed as Record<string, unknown>;
+      for (const key of ["message", "error", "detail"]) {
+        const value = record[key];
+        if (typeof value === "string" && value.trim()) {
+          return value.trim();
+        }
+      }
+    }
+
+    return JSON.stringify(parsed);
+  } catch {
+    return trimmed;
+  }
+}
+
+function withCloudClawErrorDetail(message: string, text: string): string {
+  const detail = extractCloudClawErrorDetail(text);
+  return detail ? `${message} Details: ${detail}` : message;
+}
+
+export function formatCloudClawHttpError(params: {
+  surface: CloudClawHttpSurface;
+  method: string;
+  url: string;
+  status: number;
+  text: string;
+  operation?: string;
+}): string {
+  if (params.surface === "portal-sso") {
+    if (params.status === 401 || params.status === 403) {
+      return withCloudClawErrorDetail(
+        `Cloud Claw portal-sso rejected the saved Portal session (HTTP ${params.status}). Run altllm login-wallet again, then retry.`,
+        params.text
+      );
+    }
+
+    if (params.status === 503) {
+      return withCloudClawErrorDetail(
+        "Cloud Claw portal-sso is unavailable (HTTP 503). Portal or Cloud Claw auth may be unavailable or misconfigured during the security rollout. Retry after service recovery.",
+        params.text
+      );
+    }
+  }
+
+  const operation =
+    params.operation ||
+    (params.surface === "logs"
+      ? "logs request"
+      : params.surface === "log-stream"
+        ? "log stream"
+        : `${params.method} ${params.url}`);
+
+  if (params.status === 401) {
+    return withCloudClawErrorDetail(
+      `Cloud Claw rejected the session JWT for ${operation} (HTTP 401). Run altllm login-wallet again, then retry. If this still fails, Cloud Claw auth signing may be misconfigured.`,
+      params.text
+    );
+  }
+
+  if (params.status === 403) {
+    return withCloudClawErrorDetail(
+      `Cloud Claw denied ${operation} (HTTP 403). The account may not be authorized for this Cloud Claw resource or action.`,
+      params.text
+    );
+  }
+
+  if (params.status === 503) {
+    return withCloudClawErrorDetail(
+      `Cloud Claw ${operation} is unavailable (HTTP 503). Cloud Claw may be unavailable or missing required auth signing configuration.`,
+      params.text
+    );
+  }
+
+  return withCloudClawErrorDetail(
+    `${params.method} ${params.url} failed: ${params.status}.`,
+    params.text
+  );
+}
 
 function normalizeCloudClawBaseUrl(baseUrl: string): string {
   return normalizeBaseUrl(baseUrl);
@@ -44,6 +142,61 @@ function ensureCloudClawBaseUrlAllowed(params: {
   }
 }
 
+async function requestCloudClawEndpointJson<T>(params: {
+  method: string;
+  url: string;
+  body?: unknown;
+  token?: string;
+  surface: CloudClawHttpSurface;
+  operation?: string;
+}): Promise<T> {
+  const headers: Record<string, string> = {
+    Accept: "application/json",
+  };
+
+  let payload: string | undefined;
+  if (params.body !== undefined) {
+    headers["Content-Type"] = "application/json";
+    payload = JSON.stringify(params.body);
+  }
+  if (params.token) {
+    headers.Authorization = `Bearer ${params.token}`;
+  }
+
+  const response = await fetchWithTimeout({
+    method: params.method,
+    url: params.url,
+    headers,
+    body: payload,
+  });
+  const text = await response.text();
+
+  if (!response.ok) {
+    throw new CliError(
+      formatCloudClawHttpError({
+        surface: params.surface,
+        method: params.method,
+        url: params.url,
+        status: response.status,
+        text,
+        operation: params.operation,
+      })
+    );
+  }
+
+  if (!text) {
+    return {} as T;
+  }
+
+  try {
+    return JSON.parse(text) as T;
+  } catch {
+    throw new CliError(
+      `${params.method} ${params.url} returned invalid JSON: ${text}`
+    );
+  }
+}
+
 export async function getCloudClawJwt(params: {
   baseUrl?: string;
   sessionFile: string;
@@ -60,7 +213,7 @@ export async function getCloudClawJwt(params: {
 
   const session = await loadSession(params.sessionFile || DEFAULT_SESSION_FILE);
 
-  const sso = await requestSavedPortalSessionJson<{
+  const sso = await requestCloudClawEndpointJson<{
     authenticated?: boolean;
     token?: string;
   }>({
@@ -70,10 +223,14 @@ export async function getCloudClawJwt(params: {
       token: session.token,
       force: Boolean(params.force),
     },
+    surface: "portal-sso",
+    operation: "portal-sso",
   });
 
   if (!sso.token) {
-    throw new CliError("Cloud Claw portal-sso did not return a JWT.");
+    throw new CliError(
+      "Cloud Claw portal-sso did not return a JWT. Run altllm login-wallet again, then retry. If this still fails, Cloud Claw auth signing may be misconfigured."
+    );
   }
 
   return { baseUrl, jwt: sso.token };
@@ -95,11 +252,13 @@ export async function requestCloudClawJson<T>(params: {
     allowTokenForwarding: params.allowTokenForwarding,
   });
 
-  return requestJson<T>({
+  return requestCloudClawEndpointJson<T>({
     method: params.method,
     url: `${baseUrl}${params.path}`,
     body: params.body,
     token: jwt,
+    surface: "api",
+    operation: `${params.method} ${params.path}`,
   });
 }
 

--- a/test/session-rollout.test.ts
+++ b/test/session-rollout.test.ts
@@ -85,10 +85,11 @@ async function captureStdout(fn: () => Promise<void>): Promise<string> {
 
 function assertReloginError(error: unknown): boolean {
   assert(error instanceof Error);
-  assert.match(error.message, /Saved Portal session was rejected/);
-  assert.match(error.message, /trust-domain rollout/);
+  assert.match(
+    error.message,
+    /Saved Portal session was rejected|portal-sso rejected the saved Portal session/
+  );
   assert.match(error.message, /Run altllm login-wallet again/);
-  assert.match(error.message, /session file was not deleted/);
   assert.doesNotMatch(error.message, /failed: 401/);
   assert.doesNotMatch(error.message, /failed: 403/);
   return true;
@@ -113,7 +114,13 @@ test("Portal API saved-session 401 returns a clear re-login error", async () => 
 
     await assert.rejects(
       () => credit({ baseUrl, sessionFile }),
-      assertReloginError
+      (error) => {
+        assertReloginError(error);
+        assert(error instanceof Error);
+        assert.match(error.message, /trust-domain rollout/);
+        assert.match(error.message, /session file was not deleted/);
+        return true;
+      }
     );
 
     const persistedSession = JSON.parse(await readFile(sessionFile, "utf8")) as {
@@ -149,7 +156,13 @@ test("Cloud Claw portal-sso 403 returns the saved-session re-login error", async
           sessionFile,
           allowTokenForwarding: true,
         }),
-      assertReloginError
+      (error) => {
+        assertReloginError(error);
+        assert(error instanceof Error);
+        assert.match(error.message, /portal-sso rejected/);
+        assert.match(error.message, /portal token rejected/);
+        return true;
+      }
     );
   });
 });

--- a/tests/cloud-claw-errors.test.ts
+++ b/tests/cloud-claw-errors.test.ts
@@ -1,0 +1,219 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import { cloudClawLogs } from "../src/commands/cloud-claw-logs.js";
+import {
+  getCloudClawJwt,
+  requestCloudClawJson,
+} from "../src/lib/cloud-claw.js";
+
+const CLOUD_CLAW_BASE_URL = "https://claw.altllm.ai";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      "Content-Type": "application/json",
+    },
+  });
+}
+
+function textResponse(body: string, status: number): Response {
+  return new Response(body, { status });
+}
+
+async function withSessionFile<T>(
+  callback: (sessionFile: string) => Promise<T>
+): Promise<T> {
+  const dir = await mkdtemp(join(tmpdir(), "altllm-cloud-claw-test-"));
+  const sessionFile = join(dir, "session.json");
+  await writeFile(
+    sessionFile,
+    JSON.stringify({
+      baseUrl: "https://platform-api.altllm.ai",
+      token: "saved-portal-token",
+      user: {
+        id: "user_123",
+        email: "user@example.com",
+      },
+    }),
+    "utf8"
+  );
+
+  try {
+    return await callback(sessionFile);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+async function withFetchResponses<T>(
+  responses: Response[],
+  callback: () => Promise<T>
+): Promise<T> {
+  const originalFetch = globalThis.fetch;
+  const pending = [...responses];
+  globalThis.fetch = (async () => {
+    const response = pending.shift();
+    if (!response) {
+      throw new Error("Unexpected fetch call");
+    }
+    return response;
+  }) as typeof fetch;
+
+  try {
+    const result = await callback();
+    assert.equal(pending.length, 0, "all mocked responses should be used");
+    return result;
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+}
+
+test("portal-sso 401 gives saved-session re-login guidance", async () => {
+  await withSessionFile(async (sessionFile) => {
+    await withFetchResponses(
+      [jsonResponse({ error: "session expired" }, 401)],
+      async () => {
+        await assert.rejects(
+          () => getCloudClawJwt({ sessionFile }),
+          (error) => {
+            assert.ok(error instanceof Error);
+            assert.match(error.message, /portal-sso rejected/);
+            assert.match(error.message, /altllm login-wallet/);
+            assert.match(error.message, /session expired/);
+            return true;
+          }
+        );
+      }
+    );
+  });
+});
+
+test("portal-sso 503 points to rollout or availability problems", async () => {
+  await withSessionFile(async (sessionFile) => {
+    await withFetchResponses(
+      [jsonResponse({ message: "auth service unavailable" }, 503)],
+      async () => {
+        await assert.rejects(
+          () => getCloudClawJwt({ sessionFile }),
+          (error) => {
+            assert.ok(error instanceof Error);
+            assert.match(error.message, /portal-sso is unavailable/);
+            assert.match(error.message, /security rollout/);
+            assert.match(error.message, /auth service unavailable/);
+            return true;
+          }
+        );
+      }
+    );
+  });
+});
+
+test("Cloud Claw command 403 preserves authorization context", async () => {
+  await withSessionFile(async (sessionFile) => {
+    await withFetchResponses(
+      [
+        jsonResponse({ token: "cloud-claw-jwt" }),
+        jsonResponse({ detail: "not allowed for this deployment" }, 403),
+      ],
+      async () => {
+        await assert.rejects(
+          () =>
+            requestCloudClawJson({
+              method: "GET",
+              path: "/api/vm/deployments",
+              sessionFile,
+            }),
+          (error) => {
+            assert.ok(error instanceof Error);
+            assert.match(error.message, /Cloud Claw denied GET \/api\/vm\/deployments/);
+            assert.match(error.message, /HTTP 403/);
+            assert.match(error.message, /not allowed for this deployment/);
+            return true;
+          }
+        );
+      }
+    );
+  });
+});
+
+test("one-shot logs use Cloud Claw authorization guidance", async () => {
+  await withSessionFile(async (sessionFile) => {
+    await withFetchResponses(
+      [
+        jsonResponse({ token: "cloud-claw-jwt" }),
+        jsonResponse({ detail: "paid resource required" }, 403),
+      ],
+      async () => {
+        await assert.rejects(
+          () =>
+            cloudClawLogs({
+              name: "swift-owl-9",
+              sessionFile,
+            }),
+          (error) => {
+            assert.ok(error instanceof Error);
+            assert.match(
+              error.message,
+              /Cloud Claw denied GET \/api\/vm\/deployments\/swift-owl-9\/logs/
+            );
+            assert.match(error.message, /paid resource required/);
+            return true;
+          }
+        );
+      }
+    );
+  });
+});
+
+test("log stream setup uses Cloud Claw auth signing guidance", async () => {
+  await withSessionFile(async (sessionFile) => {
+    await withFetchResponses(
+      [
+        jsonResponse({ token: "cloud-claw-jwt" }),
+        textResponse("jwt invalid", 401),
+      ],
+      async () => {
+        await assert.rejects(
+          () =>
+            cloudClawLogs({
+              name: "swift-owl-9",
+              sessionFile,
+              stream: true,
+            }),
+          (error) => {
+            assert.ok(error instanceof Error);
+            assert.match(error.message, /Cloud Claw rejected the session JWT/);
+            assert.match(error.message, /auth signing may be misconfigured/);
+            assert.match(error.message, /jwt invalid/);
+            return true;
+          }
+        );
+      }
+    );
+  });
+});
+
+test("Cloud Claw JSON success output remains parseable", async () => {
+  await withSessionFile(async (sessionFile) => {
+    const result = await withFetchResponses(
+      [
+        jsonResponse({ token: "cloud-claw-jwt" }),
+        jsonResponse({ deployments: [] }),
+      ],
+      async () =>
+        requestCloudClawJson<{ deployments: unknown[] }>({
+          method: "GET",
+          path: "/api/vm/deployments",
+          baseUrl: CLOUD_CLAW_BASE_URL,
+          sessionFile,
+        })
+    );
+
+    assert.deepEqual(result, { deployments: [] });
+  });
+});


### PR DESCRIPTION
## Summary
- Normalize Cloud Claw auth and rollout failures for `portal-sso`, JSON VM commands, one-shot logs, and log-stream setup.
- Add mocked Node tests for `401`, `403`, `503`, and successful JSON output without requiring live Cloud Claw credentials.
- Document Cloud Claw security-rollup failure interpretation in the README and shared Cloud Claw preflight notes.
- Restore the missing `validateUnsafePrivateKeyArgvUsage` import in `login-wallet` so the repo typecheck/build surface passes.

## Verification
- `npm install`
- `npm run typecheck`
- `npm run build`
- `npm test`
- Built CLI mocked smoke against a local HTTP server for `portal-sso` `401` and `cloud-claw-logs` `403`.

Refs #62
