### PR TITLE
docs: add release process

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,6 +58,8 @@ Commands that reuse a saved Portal session token, or forward that token to Cloud
   - saved session token handling
 - `src/lib/wallet.ts`
   - wallet signing and direct payment execution
+- `RELEASE.md`
+  - versioning, release checklist, and release note template
 - `skills/altllm-portal-cli/`
   - umbrella repo-local skill docs for agents
 - `skills/altllm-portal-auth/`

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ TypeScript CLI and repo-local agent skills for AltLLM Portal operations.
 
 If you want a task-oriented guide for what an agent can do with these skills, start with [GUIDE.md](./GUIDE.md).
 
+For versioning and release-note preparation, see [RELEASE.md](./RELEASE.md).
+
 ## Introduction
 
 **AltLLM** is a platform that gives users a managed way to access AltLLM models and infrastructure. In practice, the platform has two main surfaces:

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,109 @@
+# Release Process
+
+This repository releases the AltLLM Portal CLI and the repo-local skill docs together. A release version applies to both surfaces unless a release note explicitly says otherwise.
+
+## Versioning
+
+Use SemVer in `MAJOR.MINOR.PATCH` form and tag releases as `vMAJOR.MINOR.PATCH`.
+
+- `PATCH`: bug fixes, documentation corrections, tests, or skill wording changes that do not add new user-facing behavior.
+- `MINOR`: new commands, new options, new skill workflows, or backward-compatible behavior changes.
+- `MAJOR`: breaking CLI behavior, removed commands or options, incompatible session or API contract changes, or skill changes that require callers to change an established workflow.
+
+While the package is still `0.x`, use `MINOR` for breaking changes unless maintainers decide to cut `1.0.0`. Call out every breaking change in the release notes.
+
+## Release Checklist
+
+1. Start from the branch that should be released and make sure it includes all intended PRs.
+2. Confirm the working tree is clean:
+
+   ```bash
+   git status --short
+   ```
+
+3. Choose the next version and update `package.json`.
+4. Run validation:
+
+   ```bash
+   npm install
+   npm run typecheck
+   npm run build
+   npm test
+   ```
+
+5. If the release changes a live command, run an end-to-end check against the intended Portal or local environment when practical.
+6. Draft release notes as `RELEASE_NOTES.md` with the template below. This file can be temporary unless maintainers want to keep release notes in the repository.
+7. Commit the version and release-note preparation changes.
+8. Tag and push the release:
+
+   ```bash
+   git tag vX.Y.Z
+   git push origin HEAD
+   git push origin vX.Y.Z
+   ```
+
+9. Create the GitHub Release:
+
+   ```bash
+   gh release create vX.Y.Z \
+     --repo alt-research/altllm-skills \
+     --title "vX.Y.Z" \
+     --notes-file RELEASE_NOTES.md
+   ```
+
+Do not run `npm publish` as part of the default release process unless maintainers explicitly add package publishing instructions.
+
+## Release Notes
+
+Keep release notes user-facing. Mention commands, options, skill workflows, security changes, migration steps, and known operational risks. Avoid listing internal-only refactors unless they explain a visible change.
+
+Use this template:
+
+```markdown
+# vX.Y.Z - YYYY-MM-DD
+
+## Summary
+
+- One or two bullets describing the release at a high level.
+
+## Added
+
+- New commands, options, skill workflows, or documentation surfaces.
+
+## Changed
+
+- Backward-compatible behavior changes.
+
+## Fixed
+
+- Bug fixes and compatibility fixes.
+
+## Security
+
+- Token handling, wallet signing, secret input, or auth-related changes.
+
+## Breaking Changes
+
+- Required migration steps or changed behavior. Write "None" when there are none.
+
+## Validation
+
+- `npm install`
+- `npm run typecheck`
+- `npm run build`
+- `npm test`
+- Any live end-to-end checks that were run, including target environment.
+
+## Known Issues
+
+- Remaining limitations or rollout risks. Write "None" when there are none.
+```
+
+## Post-Release
+
+After publishing the GitHub Release:
+
+1. Confirm the release page points to the expected tag.
+2. Confirm issue and PR links in the release notes resolve correctly.
+3. Close the release-tracking issue if the release process and notes are complete.
+4. Announce the release in the project channel used by maintainers.


### PR DESCRIPTION
## Summary

- Add RELEASE.md with versioning rules, release checklist, GitHub Release steps, and release-note template.
- Link the release process from README and AGENTS.

Closes #69

## Validation

- `git diff --check`
- `npm run typecheck` fails on current base: `src/commands/login-wallet.ts(259,3): error TS2304: Cannot find name 'validateUnsafePrivateKeyArgvUsage'.`\n- `npm run build` fails on the same current-base TypeScript error.\n\n`npm test` was not run because it starts with `npm run build`, which currently fails for the same base issue.