### PR TITLE
epic(auth): merge security rollout compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,8 @@ node dist/cli.js cloud-claw-me
 
 If you intentionally point Cloud Claw commands at a non-trusted host with `--cloud-claw-base-url`, also pass `--allow-cloud-claw-token-forwarding`. Without that explicit override, the CLI will refuse to POST your saved Portal session token to that host.
 
+During the security-rollup transition, Cloud Claw auth failures are normalized before they reach the user. A `401` or `403` from `portal-sso` means the saved Portal session was rejected; run `altllm login-wallet` again and retry. A `503` from `portal-sso` points to Portal or Cloud Claw auth availability or rollout configuration. A `401` from VM or log routes means the Cloud Claw session JWT was rejected, while a `403` means the account is not authorized for that resource or action. Non-auth server failures still include the HTTP status and backend detail for debugging.
+
 List deployments:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -212,6 +212,16 @@ Successful login stores a session at:
 
 On POSIX systems, the CLI saves the session directory and file with private permissions (`0700` for the directory and `0600` for the file).
 
+After the AltLLM Portal session trust-domain rollout, sessions created before the rollout may be rejected by Portal API routes or Cloud Claw `portal-sso`. When that happens, saved-session commands fail with a direct re-login instruction instead of a raw endpoint error:
+
+```bash
+node dist/cli.js login-wallet \
+  --base-url https://platform-api.altllm.ai \
+  --wallet-address 0x...
+```
+
+The CLI does not delete the existing session file automatically. `login-wallet` replaces it after a successful login, or you can remove it explicitly with `logout`.
+
 Remove the local Portal session:
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "dev": "tsx src/cli.ts",
-    "test": "npm run build && node --test tests/*.test.mjs && node --import tsx --test test/**/*.test.ts",
+    "test": "npm run build && node --test tests/*.test.mjs && node --import tsx --test test/**/*.test.ts tests/*.test.ts",
     "typecheck": "tsc --noEmit"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "dev": "tsx src/cli.ts",
+    "test": "npm run build && node --test tests/*.test.mjs",
     "typecheck": "tsc --noEmit"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "build": "tsc -p tsconfig.json",
     "dev": "tsx src/cli.ts",
     "test": "npm run build && node --test tests/*.test.mjs && node --import tsx --test test/**/*.test.ts tests/*.test.ts",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit && tsc -p tsconfig.test.json"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "dev": "tsx src/cli.ts",
-    "test": "npm run build && node --test tests/*.test.mjs",
+    "test": "npm run build && node --test tests/*.test.mjs && node --import tsx --test test/**/*.test.ts",
     "typecheck": "tsc --noEmit"
   },
   "repository": {

--- a/skills/_shared/cloud-claw-preflight.md
+++ b/skills/_shared/cloud-claw-preflight.md
@@ -15,3 +15,4 @@ These notes apply when using the Cloud Claw skills from this repository.
 5. Do not default to internal build/image scripts unless the user explicitly asks for infra maintenance.
 6. Do not forward the saved Portal session token to an arbitrary Cloud Claw host by default. If a non-trusted `--cloud-claw-base-url` is truly intended, require an explicit override such as `--allow-cloud-claw-token-forwarding`.
 7. When forwarding the saved Portal session token to Cloud Claw, require `https://` for non-local `--cloud-claw-base-url` values. Only loopback local-development targets should use `http://`.
+8. During auth/security rollouts, interpret `portal-sso` `401`/`403` as saved Portal session rejection and ask the user to run `altllm login-wallet` again. Treat `portal-sso` `503` as Portal or Cloud Claw auth availability/configuration risk. Treat Cloud Claw VM/log `401` as JWT rejection and `403` as account/resource authorization denial.

--- a/skills/_shared/session-and-target.md
+++ b/skills/_shared/session-and-target.md
@@ -3,5 +3,7 @@
 - This repository targets the AltLLM Portal API, not the OpenAI-compatible gateway.
 - Use the saved Portal session for follow-up commands unless the user overrides `--session-file`.
 - The default session file is `~/.altllm/portal-cli-session.json`.
+- After the Portal session trust-domain rollout, pre-rollout saved sessions may be rejected by Portal API routes or Cloud Claw `portal-sso`; run `altllm login-wallet` again to refresh the saved session.
+- Stale-session errors should not delete the local session file implicitly. Use `altllm logout` when explicit removal is desired.
 - API keys created through Portal are meant for the AltLLM OpenAI-compatible gateway at `https://api.altllm.ai/v1`.
 - Current wallet login still requires an EVM address and Ethereum-style signature verification on the backend.

--- a/skills/altllm-portal-auth/SKILL.md
+++ b/skills/altllm-portal-auth/SKILL.md
@@ -33,6 +33,7 @@ user-invocable: true
 - For non-default, non-loopback API hosts, prefer `--prepare` and external signing instead of local auto-signing.
 - Current backend support is still limited to EVM addresses and Ethereum-style signatures.
 - Save the resulting session to `~/.altllm/portal-cli-session.json` unless overridden.
+- If saved-session commands report that the Portal session was rejected after the trust-domain rollout, run `login-wallet` again to refresh the session.
 - `logout` only removes the local session file. It does not revoke API keys.
 
 ## Reference

--- a/src/commands/cloud-claw-logs.ts
+++ b/src/commands/cloud-claw-logs.ts
@@ -52,13 +52,14 @@ export async function cloudClawLogs(options: CloudClawLogsOptions): Promise<void
     return;
   }
 
-  const streamUrl = `${normalizeBaseUrl(
+  const streamDisplayUrl = `${normalizeBaseUrl(
     baseUrl
   )}/api/vm/deployments/${name}/logs/stream`;
-  const response = await fetch(streamUrl, {
+  const streamUrl = new URL(streamDisplayUrl);
+  streamUrl.searchParams.set("auth", jwt);
+  const response = await fetch(streamUrl.toString(), {
     headers: {
       Accept: "text/event-stream",
-      Authorization: `Bearer ${jwt}`,
     },
   });
 
@@ -68,7 +69,7 @@ export async function cloudClawLogs(options: CloudClawLogsOptions): Promise<void
       formatCloudClawHttpError({
         surface: "log-stream",
         method: "GET",
-        url: streamUrl,
+        url: streamDisplayUrl,
         status: response.status,
         text,
         operation: `GET /api/vm/deployments/${name}/logs/stream`,

--- a/src/commands/cloud-claw-logs.ts
+++ b/src/commands/cloud-claw-logs.ts
@@ -1,5 +1,10 @@
 import { CliError, fetchWithTimeout, normalizeBaseUrl } from "../lib/api.js";
-import { DEFAULT_CLOUD_CLAW_BASE_URL, getCloudClawJwt, validateDeploymentName } from "../lib/cloud-claw.js";
+import {
+  DEFAULT_CLOUD_CLAW_BASE_URL,
+  formatCloudClawHttpError,
+  getCloudClawJwt,
+  validateDeploymentName,
+} from "../lib/cloud-claw.js";
 import { DEFAULT_SESSION_FILE } from "../lib/session.js";
 
 export interface CloudClawLogsOptions {
@@ -21,9 +26,10 @@ export async function cloudClawLogs(options: CloudClawLogsOptions): Promise<void
   });
 
   if (!options.stream) {
+    const url = `${normalizeBaseUrl(baseUrl)}/api/vm/deployments/${name}/logs`;
     const response = await fetchWithTimeout({
       method: "GET",
-      url: `${normalizeBaseUrl(baseUrl)}/api/vm/deployments/${name}/logs`,
+      url,
       headers: {
         Accept: "application/json",
         Authorization: `Bearer ${jwt}`,
@@ -31,26 +37,42 @@ export async function cloudClawLogs(options: CloudClawLogsOptions): Promise<void
     });
     const text = await response.text();
     if (!response.ok) {
-      throw new CliError(`GET ${baseUrl}/api/vm/deployments/${name}/logs failed: ${response.status} ${text}`);
+      throw new CliError(
+        formatCloudClawHttpError({
+          surface: "logs",
+          method: "GET",
+          url,
+          status: response.status,
+          text,
+          operation: `GET /api/vm/deployments/${name}/logs`,
+        })
+      );
     }
     process.stdout.write(text.endsWith("\n") ? text : `${text}\n`);
     return;
   }
 
-  const response = await fetch(
-    `${normalizeBaseUrl(baseUrl)}/api/vm/deployments/${name}/logs/stream`,
-    {
-      headers: {
-        Accept: "text/event-stream",
-        Authorization: `Bearer ${jwt}`,
-      },
-    }
-  );
+  const streamUrl = `${normalizeBaseUrl(
+    baseUrl
+  )}/api/vm/deployments/${name}/logs/stream`;
+  const response = await fetch(streamUrl, {
+    headers: {
+      Accept: "text/event-stream",
+      Authorization: `Bearer ${jwt}`,
+    },
+  });
 
   if (!response.ok || !response.body) {
     const text = await response.text();
     throw new CliError(
-      `GET ${baseUrl}/api/vm/deployments/${name}/logs/stream failed: ${response.status} ${text}`
+      formatCloudClawHttpError({
+        surface: "log-stream",
+        method: "GET",
+        url: streamUrl,
+        status: response.status,
+        text,
+        operation: `GET /api/vm/deployments/${name}/logs/stream`,
+      })
     );
   }
 

--- a/src/commands/create-api-key.ts
+++ b/src/commands/create-api-key.ts
@@ -1,4 +1,4 @@
-import { requestJson } from "../lib/api.js";
+import { requestSavedPortalSessionJson } from "../lib/api.js";
 import {
   buildKeyPermissions,
   CreateKeyResponse,
@@ -30,7 +30,7 @@ export async function createApiKey(options: CreateApiKeyOptions): Promise<void> 
     allowTokenHostMismatch: options.allowTokenHostMismatch,
   });
 
-  const result = await requestJson<CreateKeyResponse>({
+  const result = await requestSavedPortalSessionJson<CreateKeyResponse>({
     method: "POST",
     url: `${baseUrl}/api/keys`,
     token,

--- a/src/commands/credit.ts
+++ b/src/commands/credit.ts
@@ -1,4 +1,4 @@
-import { normalizeBaseUrl, requestJson } from "../lib/api.js";
+import { normalizeBaseUrl, requestSavedPortalSessionJson } from "../lib/api.js";
 import {
   DEFAULT_SESSION_FILE,
   loadSession,
@@ -21,7 +21,7 @@ export async function credit(options: CreditOptions): Promise<void> {
     })
   );
 
-  const result = await requestJson<Record<string, unknown>>({
+  const result = await requestSavedPortalSessionJson<Record<string, unknown>>({
     method: "GET",
     url: `${baseUrl}/api/billing/balance`,
     token: session.token,

--- a/src/commands/get-api-key.ts
+++ b/src/commands/get-api-key.ts
@@ -1,4 +1,4 @@
-import { requestJson } from "../lib/api.js";
+import { requestSavedPortalSessionJson } from "../lib/api.js";
 import { KeyDetail, resolvePortalContext, writeJson } from "../lib/keys.js";
 import { DEFAULT_SESSION_FILE } from "../lib/session.js";
 
@@ -16,7 +16,7 @@ export async function getApiKey(options: GetApiKeyOptions): Promise<void> {
     allowTokenHostMismatch: options.allowTokenHostMismatch,
   });
 
-  const result = await requestJson<KeyDetail>({
+  const result = await requestSavedPortalSessionJson<KeyDetail>({
     method: "GET",
     url: `${baseUrl}/api/keys/${options.keyId}`,
     token,

--- a/src/commands/list-api-keys.ts
+++ b/src/commands/list-api-keys.ts
@@ -1,4 +1,4 @@
-import { requestJson } from "../lib/api.js";
+import { requestSavedPortalSessionJson } from "../lib/api.js";
 import { ListKeysResponse, resolvePortalContext, writeJson } from "../lib/keys.js";
 import { DEFAULT_SESSION_FILE } from "../lib/session.js";
 
@@ -15,7 +15,7 @@ export async function listApiKeys(options: ListApiKeysOptions): Promise<void> {
     allowTokenHostMismatch: options.allowTokenHostMismatch,
   });
 
-  const result = await requestJson<ListKeysResponse>({
+  const result = await requestSavedPortalSessionJson<ListKeysResponse>({
     method: "GET",
     url: `${baseUrl}/api/keys`,
     token,

--- a/src/commands/login-wallet.ts
+++ b/src/commands/login-wallet.ts
@@ -4,6 +4,7 @@ import {
   normalizeWalletSignature,
   resolvePrivateKey,
   signChallengeMessage,
+  validateUnsafePrivateKeyArgvUsage,
 } from "../lib/wallet.js";
 
 interface CryptoChallengeResponse {
@@ -15,7 +16,7 @@ interface CryptoChallengeResponse {
 }
 
 interface LoginResponse {
-  token: string;
+  token?: string;
   user: {
     id: string;
     email: string;
@@ -49,6 +50,9 @@ interface ParsedChallengeMessage {
 
 const TRUSTED_PORTAL_API_ORIGIN = "https://platform-api.altllm.ai";
 const TRUSTED_PORTAL_FRONTEND_ORIGIN = "https://platform.altllm.ai";
+const PORTAL_TOKEN_OPT_IN_HEADERS = {
+  "X-AltLLM-Return-Portal-Token": "1",
+};
 const CHALLENGE_MESSAGE_RE =
   /^([^\n]+) wants you to sign in with your Ethereum account:\n(0x[a-fA-F0-9]{40})\n\nSign this message to log in to AltLLM Portal\.\n\nURI: ([^\n]+)\nVersion: ([^\n]+)\nChain ID: ([^\n]+)\nNonce: ([^\n]+)\nIssued At: ([^\n]+)\nExpiration Time: ([^\n]+)$/;
 
@@ -64,6 +68,17 @@ function normalizeWalletAddress(walletAddress: string): string {
   }
 
   return walletAddress.toLowerCase();
+}
+
+function requirePortalSessionToken(login: LoginResponse): string {
+  const token = login.token?.trim();
+  if (!token) {
+    throw new CliError(
+      "Portal login response did not include a session token. This CLI requires the Portal API to honor X-AltLLM-Return-Portal-Token: 1 during wallet login."
+    );
+  }
+
+  return token;
 }
 
 function canonicalizeOrigin(url: string): string {
@@ -271,16 +286,18 @@ export async function loginWallet(options: LoginWalletOptions): Promise<void> {
     const login = await requestJson<LoginResponse>({
       method: "POST",
       url: `${baseUrl}/api/auth/crypto/verify`,
+      headers: PORTAL_TOKEN_OPT_IN_HEADERS,
       body: {
         wallet_address: walletAddress,
         nonce: options.nonce.trim(),
         signature: normalizeWalletSignature(options.signature),
       },
     });
+    const token = requirePortalSessionToken(login);
 
     await saveSession(options.sessionFile || DEFAULT_SESSION_FILE, {
       baseUrl,
-      token: login.token,
+      token,
       user: login.user,
     });
 
@@ -376,16 +393,18 @@ export async function loginWallet(options: LoginWalletOptions): Promise<void> {
   const login = await requestJson<LoginResponse>({
     method: "POST",
     url: `${baseUrl}/api/auth/crypto/verify`,
+    headers: PORTAL_TOKEN_OPT_IN_HEADERS,
     body: {
       wallet_address: walletAddress,
       nonce: challenge.nonce,
       signature,
     },
   });
+  const token = requirePortalSessionToken(login);
 
   await saveSession(options.sessionFile || DEFAULT_SESSION_FILE, {
     baseUrl,
-    token: login.token,
+    token,
     user: login.user,
   });
 

--- a/src/commands/redeem-promo.ts
+++ b/src/commands/redeem-promo.ts
@@ -1,4 +1,4 @@
-import { normalizeBaseUrl, requestJson } from "../lib/api.js";
+import { normalizeBaseUrl, requestSavedPortalSessionJson } from "../lib/api.js";
 import {
   DEFAULT_SESSION_FILE,
   loadSession,
@@ -22,7 +22,7 @@ export async function redeemPromo(options: RedeemPromoOptions): Promise<void> {
     })
   );
 
-  const result = await requestJson<Record<string, unknown>>({
+  const result = await requestSavedPortalSessionJson<Record<string, unknown>>({
     method: "POST",
     url: `${baseUrl}/api/billing/redeem-promo`,
     token: session.token,

--- a/src/commands/revoke-api-key.ts
+++ b/src/commands/revoke-api-key.ts
@@ -1,4 +1,4 @@
-import { requestJson } from "../lib/api.js";
+import { requestSavedPortalSessionJson } from "../lib/api.js";
 import {
   KeyDeletedResponse,
   resolvePortalContext,
@@ -20,7 +20,7 @@ export async function revokeApiKey(options: RevokeApiKeyOptions): Promise<void> 
     allowTokenHostMismatch: options.allowTokenHostMismatch,
   });
 
-  const result = await requestJson<KeyDeletedResponse>({
+  const result = await requestSavedPortalSessionJson<KeyDeletedResponse>({
     method: "DELETE",
     url: `${baseUrl}/api/keys/${options.keyId}`,
     token,

--- a/src/commands/topup-crypto.ts
+++ b/src/commands/topup-crypto.ts
@@ -1,4 +1,8 @@
-import { CliError, normalizeBaseUrl, requestJson } from "../lib/api.js";
+import {
+  CliError,
+  normalizeBaseUrl,
+  requestSavedPortalSessionJson,
+} from "../lib/api.js";
 import {
   DEFAULT_SESSION_FILE,
   loadSession,
@@ -85,7 +89,7 @@ export async function fetchPaymentLinkStatus(
   token: string,
   paymentLinkId: string
 ): Promise<PaymentLinkRecord> {
-  const payload = await requestJson<PaymentLinksResponse>({
+  const payload = await requestSavedPortalSessionJson<PaymentLinksResponse>({
     method: "GET",
     url: `${baseUrl}/api/billing/payment-links?limit=${PAYMENT_LINK_LOOKUP_LIMIT}`,
     token,
@@ -203,7 +207,7 @@ export async function topupCrypto(options: TopupCryptoOptions): Promise<void> {
     })
   );
 
-  const created = await requestJson<CreatePaymentLinkResponse>({
+  const created = await requestSavedPortalSessionJson<CreatePaymentLinkResponse>({
     method: "POST",
     url: `${baseUrl}/api/billing/payment-link`,
     token: session.token,

--- a/src/commands/transactions.ts
+++ b/src/commands/transactions.ts
@@ -1,4 +1,4 @@
-import { requestJson } from "../lib/api.js";
+import { requestSavedPortalSessionJson } from "../lib/api.js";
 import {
   appendPaginationParams,
   parseTransactionFilterType,
@@ -33,7 +33,7 @@ export async function transactions(options: TransactionsOptions): Promise<void> 
   }
 
   const suffix = searchParams.size > 0 ? `?${searchParams.toString()}` : "";
-  const result = await requestJson<Record<string, unknown>>({
+  const result = await requestSavedPortalSessionJson<Record<string, unknown>>({
     method: "GET",
     url: `${baseUrl}/api/billing/transactions${suffix}`,
     token,

--- a/src/commands/update-api-key.ts
+++ b/src/commands/update-api-key.ts
@@ -1,4 +1,4 @@
-import { CliError, requestJson } from "../lib/api.js";
+import { CliError, requestSavedPortalSessionJson } from "../lib/api.js";
 import {
   buildKeyPermissions,
   KeyDetail,
@@ -55,7 +55,7 @@ export async function updateApiKey(options: UpdateApiKeyOptions): Promise<void> 
     allowTokenHostMismatch: options.allowTokenHostMismatch,
   });
 
-  const result = await requestJson<KeyDetail>({
+  const result = await requestSavedPortalSessionJson<KeyDetail>({
     method: "PATCH",
     url: `${baseUrl}/api/keys/${options.keyId}`,
     token,

--- a/src/commands/usage-by-key.ts
+++ b/src/commands/usage-by-key.ts
@@ -1,4 +1,4 @@
-import { requestJson } from "../lib/api.js";
+import { requestSavedPortalSessionJson } from "../lib/api.js";
 import { appendRequiredDateRangeParams } from "../lib/history.js";
 import { resolvePortalContext, writeJson } from "../lib/keys.js";
 import { DEFAULT_SESSION_FILE } from "../lib/session.js";
@@ -25,7 +25,7 @@ export async function usageByKey(options: UsageByKeyOptions): Promise<void> {
   });
 
   const suffix = searchParams.size > 0 ? `?${searchParams.toString()}` : "";
-  const result = await requestJson<Record<string, unknown>>({
+  const result = await requestSavedPortalSessionJson<Record<string, unknown>>({
     method: "GET",
     url: `${baseUrl}/api/usage/by-key${suffix}`,
     token,

--- a/src/commands/usage-by-model.ts
+++ b/src/commands/usage-by-model.ts
@@ -1,4 +1,4 @@
-import { requestJson } from "../lib/api.js";
+import { requestSavedPortalSessionJson } from "../lib/api.js";
 import { appendMonthOrDateRangeParams } from "../lib/history.js";
 import { resolvePortalContext, writeJson } from "../lib/keys.js";
 import { DEFAULT_SESSION_FILE } from "../lib/session.js";
@@ -27,7 +27,7 @@ export async function usageByModel(options: UsageByModelOptions): Promise<void> 
   });
 
   const suffix = searchParams.size > 0 ? `?${searchParams.toString()}` : "";
-  const result = await requestJson<Record<string, unknown>>({
+  const result = await requestSavedPortalSessionJson<Record<string, unknown>>({
     method: "GET",
     url: `${baseUrl}/api/usage/by-model${suffix}`,
     token,

--- a/src/commands/usage-summary.ts
+++ b/src/commands/usage-summary.ts
@@ -1,4 +1,4 @@
-import { requestJson } from "../lib/api.js";
+import { requestSavedPortalSessionJson } from "../lib/api.js";
 import { resolvePortalContext, writeJson } from "../lib/keys.js";
 import { DEFAULT_SESSION_FILE } from "../lib/session.js";
 
@@ -15,7 +15,7 @@ export async function usageSummary(options: UsageSummaryOptions): Promise<void> 
     allowTokenHostMismatch: options.allowTokenHostMismatch,
   });
 
-  const result = await requestJson<Record<string, unknown>>({
+  const result = await requestSavedPortalSessionJson<Record<string, unknown>>({
     method: "GET",
     url: `${baseUrl}/api/usage/summary`,
     token,

--- a/src/commands/usage-timeline.ts
+++ b/src/commands/usage-timeline.ts
@@ -1,4 +1,4 @@
-import { requestJson } from "../lib/api.js";
+import { requestSavedPortalSessionJson } from "../lib/api.js";
 import { appendMonthOrDateRangeParams } from "../lib/history.js";
 import { resolvePortalContext, writeJson } from "../lib/keys.js";
 import { DEFAULT_SESSION_FILE } from "../lib/session.js";
@@ -27,7 +27,7 @@ export async function usageTimeline(options: UsageTimelineOptions): Promise<void
   });
 
   const suffix = searchParams.size > 0 ? `?${searchParams.toString()}` : "";
-  const result = await requestJson<Record<string, unknown>>({
+  const result = await requestSavedPortalSessionJson<Record<string, unknown>>({
     method: "GET",
     url: `${baseUrl}/api/usage/timeline${suffix}`,
     token,

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -130,14 +130,17 @@ export async function requestJson<T>({
   url,
   body,
   token,
+  headers: extraHeaders,
 }: {
   method: string;
   url: string;
   body?: unknown;
   token?: string;
+  headers?: Record<string, string>;
 }): Promise<T> {
   const headers: Record<string, string> = {
     Accept: "application/json",
+    ...extraHeaders,
   };
 
   let payload: string | undefined;

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -6,6 +6,33 @@ export class CliError extends Error {
 }
 
 const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
+const SAVED_PORTAL_SESSION_RELOGIN_MESSAGE =
+  "Run altllm login-wallet again to refresh the saved Portal session, then retry this command.";
+
+interface RequestJsonOptions {
+  method: string;
+  url: string;
+  body?: unknown;
+  token?: string;
+  headers?: Record<string, string>;
+  savedPortalSession?: boolean;
+}
+
+function isAuthFailureStatus(status: number): boolean {
+  return status === 401 || status === 403;
+}
+
+function formatSavedPortalSessionAuthFailure(params: {
+  method: string;
+  url: string;
+  status: number;
+}): string {
+  return (
+    `Saved Portal session was rejected by ${params.method} ${params.url} (${params.status}). ` +
+    "This can happen if the session expired or was created before the AltLLM Portal session trust-domain rollout. " +
+    `${SAVED_PORTAL_SESSION_RELOGIN_MESSAGE} The session file was not deleted.`
+  );
+}
 
 function parseBaseUrl(baseUrl: string): URL {
   let parsed: URL;
@@ -131,13 +158,8 @@ export async function requestJson<T>({
   body,
   token,
   headers: extraHeaders,
-}: {
-  method: string;
-  url: string;
-  body?: unknown;
-  token?: string;
-  headers?: Record<string, string>;
-}): Promise<T> {
+  savedPortalSession,
+}: RequestJsonOptions): Promise<T> {
   const headers: Record<string, string> = {
     Accept: "application/json",
     ...extraHeaders,
@@ -162,6 +184,16 @@ export async function requestJson<T>({
   const text = await response.text();
 
   if (!response.ok) {
+    if (savedPortalSession && isAuthFailureStatus(response.status)) {
+      throw new CliError(
+        formatSavedPortalSessionAuthFailure({
+          method,
+          url,
+          status: response.status,
+        })
+      );
+    }
+
     throw new CliError(`${method} ${url} failed: ${response.status} ${text}`);
   }
 
@@ -174,4 +206,13 @@ export async function requestJson<T>({
   } catch {
     throw new CliError(`${method} ${url} returned invalid JSON: ${text}`);
   }
+}
+
+export async function requestSavedPortalSessionJson<T>(
+  params: Omit<RequestJsonOptions, "savedPortalSession">
+): Promise<T> {
+  return requestJson<T>({
+    ...params,
+    savedPortalSession: true,
+  });
 }

--- a/src/lib/cloud-claw.ts
+++ b/src/lib/cloud-claw.ts
@@ -1,9 +1,8 @@
 import {
   canonicalizeOrigin,
   CliError,
+  fetchWithTimeout,
   normalizeBaseUrl,
-  requestJson,
-  requestSavedPortalSessionJson,
   requireSecureNonLocalBaseUrl,
 } from "./api.js";
 import { DEFAULT_SESSION_FILE, loadSession } from "./session.js";
@@ -14,6 +13,105 @@ export const DEFAULT_CLOUD_CLAW_BASE_URL =
 
 export const CLOUD_CLAW_AGENT_TYPES = ["openclaw", "picoclaw", "aintern"] as const;
 export type CloudClawAgentType = (typeof CLOUD_CLAW_AGENT_TYPES)[number];
+
+export type CloudClawHttpSurface =
+  | "portal-sso"
+  | "api"
+  | "logs"
+  | "log-stream";
+
+function extractCloudClawErrorDetail(text: string): string {
+  const trimmed = text.trim();
+  if (!trimmed) {
+    return "";
+  }
+
+  try {
+    const parsed = JSON.parse(trimmed) as unknown;
+
+    if (typeof parsed === "string") {
+      return parsed.trim();
+    }
+
+    if (typeof parsed === "object" && parsed !== null) {
+      const record = parsed as Record<string, unknown>;
+      for (const key of ["message", "error", "detail"]) {
+        const value = record[key];
+        if (typeof value === "string" && value.trim()) {
+          return value.trim();
+        }
+      }
+    }
+
+    return JSON.stringify(parsed);
+  } catch {
+    return trimmed;
+  }
+}
+
+function withCloudClawErrorDetail(message: string, text: string): string {
+  const detail = extractCloudClawErrorDetail(text);
+  return detail ? `${message} Details: ${detail}` : message;
+}
+
+export function formatCloudClawHttpError(params: {
+  surface: CloudClawHttpSurface;
+  method: string;
+  url: string;
+  status: number;
+  text: string;
+  operation?: string;
+}): string {
+  if (params.surface === "portal-sso") {
+    if (params.status === 401 || params.status === 403) {
+      return withCloudClawErrorDetail(
+        `Cloud Claw portal-sso rejected the saved Portal session (HTTP ${params.status}). Run altllm login-wallet again, then retry.`,
+        params.text
+      );
+    }
+
+    if (params.status === 503) {
+      return withCloudClawErrorDetail(
+        "Cloud Claw portal-sso is unavailable (HTTP 503). Portal or Cloud Claw auth may be unavailable or misconfigured during the security rollout. Retry after service recovery.",
+        params.text
+      );
+    }
+  }
+
+  const operation =
+    params.operation ||
+    (params.surface === "logs"
+      ? "logs request"
+      : params.surface === "log-stream"
+        ? "log stream"
+        : `${params.method} ${params.url}`);
+
+  if (params.status === 401) {
+    return withCloudClawErrorDetail(
+      `Cloud Claw rejected the session JWT for ${operation} (HTTP 401). Run altllm login-wallet again, then retry. If this still fails, Cloud Claw auth signing may be misconfigured.`,
+      params.text
+    );
+  }
+
+  if (params.status === 403) {
+    return withCloudClawErrorDetail(
+      `Cloud Claw denied ${operation} (HTTP 403). The account may not be authorized for this Cloud Claw resource or action.`,
+      params.text
+    );
+  }
+
+  if (params.status === 503) {
+    return withCloudClawErrorDetail(
+      `Cloud Claw ${operation} is unavailable (HTTP 503). Cloud Claw may be unavailable or missing required auth signing configuration.`,
+      params.text
+    );
+  }
+
+  return withCloudClawErrorDetail(
+    `${params.method} ${params.url} failed: ${params.status}.`,
+    params.text
+  );
+}
 
 function normalizeCloudClawBaseUrl(baseUrl: string): string {
   return normalizeBaseUrl(baseUrl);
@@ -44,6 +142,61 @@ function ensureCloudClawBaseUrlAllowed(params: {
   }
 }
 
+async function requestCloudClawEndpointJson<T>(params: {
+  method: string;
+  url: string;
+  body?: unknown;
+  token?: string;
+  surface: CloudClawHttpSurface;
+  operation?: string;
+}): Promise<T> {
+  const headers: Record<string, string> = {
+    Accept: "application/json",
+  };
+
+  let payload: string | undefined;
+  if (params.body !== undefined) {
+    headers["Content-Type"] = "application/json";
+    payload = JSON.stringify(params.body);
+  }
+  if (params.token) {
+    headers.Authorization = `Bearer ${params.token}`;
+  }
+
+  const response = await fetchWithTimeout({
+    method: params.method,
+    url: params.url,
+    headers,
+    body: payload,
+  });
+  const text = await response.text();
+
+  if (!response.ok) {
+    throw new CliError(
+      formatCloudClawHttpError({
+        surface: params.surface,
+        method: params.method,
+        url: params.url,
+        status: response.status,
+        text,
+        operation: params.operation,
+      })
+    );
+  }
+
+  if (!text) {
+    return {} as T;
+  }
+
+  try {
+    return JSON.parse(text) as T;
+  } catch {
+    throw new CliError(
+      `${params.method} ${params.url} returned invalid JSON: ${text}`
+    );
+  }
+}
+
 export async function getCloudClawJwt(params: {
   baseUrl?: string;
   sessionFile: string;
@@ -60,7 +213,7 @@ export async function getCloudClawJwt(params: {
 
   const session = await loadSession(params.sessionFile || DEFAULT_SESSION_FILE);
 
-  const sso = await requestSavedPortalSessionJson<{
+  const sso = await requestCloudClawEndpointJson<{
     authenticated?: boolean;
     token?: string;
   }>({
@@ -70,10 +223,14 @@ export async function getCloudClawJwt(params: {
       token: session.token,
       force: Boolean(params.force),
     },
+    surface: "portal-sso",
+    operation: "portal-sso",
   });
 
   if (!sso.token) {
-    throw new CliError("Cloud Claw portal-sso did not return a JWT.");
+    throw new CliError(
+      "Cloud Claw portal-sso did not return a JWT. Run altllm login-wallet again, then retry. If this still fails, Cloud Claw auth signing may be misconfigured."
+    );
   }
 
   return { baseUrl, jwt: sso.token };
@@ -95,11 +252,13 @@ export async function requestCloudClawJson<T>(params: {
     allowTokenForwarding: params.allowTokenForwarding,
   });
 
-  return requestJson<T>({
+  return requestCloudClawEndpointJson<T>({
     method: params.method,
     url: `${baseUrl}${params.path}`,
     body: params.body,
     token: jwt,
+    surface: "api",
+    operation: `${params.method} ${params.path}`,
   });
 }
 

--- a/src/lib/cloud-claw.ts
+++ b/src/lib/cloud-claw.ts
@@ -3,6 +3,7 @@ import {
   CliError,
   normalizeBaseUrl,
   requestJson,
+  requestSavedPortalSessionJson,
   requireSecureNonLocalBaseUrl,
 } from "./api.js";
 import { DEFAULT_SESSION_FILE, loadSession } from "./session.js";
@@ -59,7 +60,10 @@ export async function getCloudClawJwt(params: {
 
   const session = await loadSession(params.sessionFile || DEFAULT_SESSION_FILE);
 
-  const sso = await requestJson<{ authenticated?: boolean; token?: string }>({
+  const sso = await requestSavedPortalSessionJson<{
+    authenticated?: boolean;
+    token?: string;
+  }>({
     method: "POST",
     url: `${baseUrl}/api/auth/portal-sso`,
     body: {

--- a/test/session-rollout.test.ts
+++ b/test/session-rollout.test.ts
@@ -1,0 +1,183 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test, { afterEach } from "node:test";
+
+import { credit } from "../src/commands/credit.js";
+import { getCloudClawJwt } from "../src/lib/cloud-claw.js";
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+async function withTempDir<T>(fn: (dir: string) => Promise<T>): Promise<T> {
+  const dir = await mkdtemp(join(tmpdir(), "altllm-session-rollout-"));
+  try {
+    return await fn(dir);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+async function writeSessionFile(params: {
+  dir: string;
+  baseUrl: string;
+  token?: string;
+}): Promise<string> {
+  const sessionFile = join(params.dir, "portal-cli-session.json");
+  await writeFile(
+    sessionFile,
+    JSON.stringify(
+      {
+        baseUrl: params.baseUrl,
+        token: params.token ?? "pre-rollout-token",
+        user: {
+          id: "user_123",
+          email: "user@example.com",
+          name: null,
+        },
+      },
+      null,
+      2
+    ),
+    "utf8"
+  );
+  return sessionFile;
+}
+
+function mockFetch(
+  handler: (params: {
+    url: string;
+    init?: RequestInit;
+  }) => Response | Promise<Response>
+): void {
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url =
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : input.url;
+    return handler({ url, init });
+  }) as typeof fetch;
+}
+
+async function captureStdout(fn: () => Promise<void>): Promise<string> {
+  const chunks: string[] = [];
+  const originalWrite = process.stdout.write;
+  process.stdout.write = ((chunk: unknown, ...args: unknown[]) => {
+    chunks.push(String(chunk));
+    const callback = args.find((arg): arg is () => void => typeof arg === "function");
+    callback?.();
+    return true;
+  }) as typeof process.stdout.write;
+
+  try {
+    await fn();
+    return chunks.join("");
+  } finally {
+    process.stdout.write = originalWrite;
+  }
+}
+
+function assertReloginError(error: unknown): boolean {
+  assert(error instanceof Error);
+  assert.match(error.message, /Saved Portal session was rejected/);
+  assert.match(error.message, /trust-domain rollout/);
+  assert.match(error.message, /Run altllm login-wallet again/);
+  assert.match(error.message, /session file was not deleted/);
+  assert.doesNotMatch(error.message, /failed: 401/);
+  assert.doesNotMatch(error.message, /failed: 403/);
+  return true;
+}
+
+test("Portal API saved-session 401 returns a clear re-login error", async () => {
+  await withTempDir(async (dir) => {
+    const baseUrl = "http://127.0.0.1:7040";
+    const sessionFile = await writeSessionFile({ dir, baseUrl });
+
+    mockFetch(({ url, init }) => {
+      assert.equal(url, `${baseUrl}/api/billing/balance`);
+      assert.equal(init?.headers instanceof Headers, false);
+      assert.equal(
+        (init?.headers as Record<string, string>).Authorization,
+        "Bearer pre-rollout-token"
+      );
+      return new Response(JSON.stringify({ error: "invalid token" }), {
+        status: 401,
+      });
+    });
+
+    await assert.rejects(
+      () => credit({ baseUrl, sessionFile }),
+      assertReloginError
+    );
+
+    const persistedSession = JSON.parse(await readFile(sessionFile, "utf8")) as {
+      token: string;
+    };
+    assert.equal(persistedSession.token, "pre-rollout-token");
+  });
+});
+
+test("Cloud Claw portal-sso 403 returns the saved-session re-login error", async () => {
+  await withTempDir(async (dir) => {
+    const sessionFile = await writeSessionFile({
+      dir,
+      baseUrl: "https://platform-api.altllm.ai",
+    });
+    const cloudClawBaseUrl = "http://127.0.0.1:7041";
+
+    mockFetch(async ({ url, init }) => {
+      assert.equal(url, `${cloudClawBaseUrl}/api/auth/portal-sso`);
+      assert.deepEqual(JSON.parse(String(init?.body)), {
+        token: "pre-rollout-token",
+        force: false,
+      });
+      return new Response(JSON.stringify({ error: "portal token rejected" }), {
+        status: 403,
+      });
+    });
+
+    await assert.rejects(
+      () =>
+        getCloudClawJwt({
+          baseUrl: cloudClawBaseUrl,
+          sessionFile,
+          allowTokenForwarding: true,
+        }),
+      assertReloginError
+    );
+  });
+});
+
+test("valid saved sessions continue to return command JSON", async () => {
+  await withTempDir(async (dir) => {
+    const baseUrl = "http://127.0.0.1:7040";
+    const sessionFile = await writeSessionFile({ dir, baseUrl, token: "valid-token" });
+
+    mockFetch(({ url, init }) => {
+      assert.equal(url, `${baseUrl}/api/billing/balance`);
+      assert.equal(
+        (init?.headers as Record<string, string>).Authorization,
+        "Bearer valid-token"
+      );
+      return new Response(
+        JSON.stringify({
+          balance: 12.5,
+          currency: "USD",
+        }),
+        { status: 200 }
+      );
+    });
+
+    const stdout = await captureStdout(() => credit({ baseUrl, sessionFile }));
+    assert.deepEqual(JSON.parse(stdout), {
+      balance: 12.5,
+      currency: "USD",
+    });
+  });
+});

--- a/test/session-rollout.test.ts
+++ b/test/session-rollout.test.ts
@@ -85,10 +85,11 @@ async function captureStdout(fn: () => Promise<void>): Promise<string> {
 
 function assertReloginError(error: unknown): boolean {
   assert(error instanceof Error);
-  assert.match(error.message, /Saved Portal session was rejected/);
-  assert.match(error.message, /trust-domain rollout/);
+  assert.match(
+    error.message,
+    /Saved Portal session was rejected|portal-sso rejected the saved Portal session/
+  );
   assert.match(error.message, /Run altllm login-wallet again/);
-  assert.match(error.message, /session file was not deleted/);
   assert.doesNotMatch(error.message, /failed: 401/);
   assert.doesNotMatch(error.message, /failed: 403/);
   return true;
@@ -113,7 +114,13 @@ test("Portal API saved-session 401 returns a clear re-login error", async () => 
 
     await assert.rejects(
       () => credit({ baseUrl, sessionFile }),
-      assertReloginError
+      (error) => {
+        assertReloginError(error);
+        assert(error instanceof Error);
+        assert.match(error.message, /trust-domain rollout/);
+        assert.match(error.message, /session file was not deleted/);
+        return true;
+      }
     );
 
     const persistedSession = JSON.parse(await readFile(sessionFile, "utf8")) as {
@@ -149,7 +156,13 @@ test("Cloud Claw portal-sso 403 returns the saved-session re-login error", async
           sessionFile,
           allowTokenForwarding: true,
         }),
-      assertReloginError
+      (error) => {
+        assertReloginError(error);
+        assert(error instanceof Error);
+        assert.match(error.message, /portal-sso rejected/);
+        assert.match(error.message, /portal token rejected/);
+        return true;
+      }
     );
   });
 });

--- a/tests/cloud-claw-errors.test.ts
+++ b/tests/cloud-claw-errors.test.ts
@@ -1,0 +1,219 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import { cloudClawLogs } from "../src/commands/cloud-claw-logs.js";
+import {
+  getCloudClawJwt,
+  requestCloudClawJson,
+} from "../src/lib/cloud-claw.js";
+
+const CLOUD_CLAW_BASE_URL = "https://claw.altllm.ai";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      "Content-Type": "application/json",
+    },
+  });
+}
+
+function textResponse(body: string, status: number): Response {
+  return new Response(body, { status });
+}
+
+async function withSessionFile<T>(
+  callback: (sessionFile: string) => Promise<T>
+): Promise<T> {
+  const dir = await mkdtemp(join(tmpdir(), "altllm-cloud-claw-test-"));
+  const sessionFile = join(dir, "session.json");
+  await writeFile(
+    sessionFile,
+    JSON.stringify({
+      baseUrl: "https://platform-api.altllm.ai",
+      token: "saved-portal-token",
+      user: {
+        id: "user_123",
+        email: "user@example.com",
+      },
+    }),
+    "utf8"
+  );
+
+  try {
+    return await callback(sessionFile);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+async function withFetchResponses<T>(
+  responses: Response[],
+  callback: () => Promise<T>
+): Promise<T> {
+  const originalFetch = globalThis.fetch;
+  const pending = [...responses];
+  globalThis.fetch = (async () => {
+    const response = pending.shift();
+    if (!response) {
+      throw new Error("Unexpected fetch call");
+    }
+    return response;
+  }) as typeof fetch;
+
+  try {
+    const result = await callback();
+    assert.equal(pending.length, 0, "all mocked responses should be used");
+    return result;
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+}
+
+test("portal-sso 401 gives saved-session re-login guidance", async () => {
+  await withSessionFile(async (sessionFile) => {
+    await withFetchResponses(
+      [jsonResponse({ error: "session expired" }, 401)],
+      async () => {
+        await assert.rejects(
+          () => getCloudClawJwt({ sessionFile }),
+          (error) => {
+            assert.ok(error instanceof Error);
+            assert.match(error.message, /portal-sso rejected/);
+            assert.match(error.message, /altllm login-wallet/);
+            assert.match(error.message, /session expired/);
+            return true;
+          }
+        );
+      }
+    );
+  });
+});
+
+test("portal-sso 503 points to rollout or availability problems", async () => {
+  await withSessionFile(async (sessionFile) => {
+    await withFetchResponses(
+      [jsonResponse({ message: "auth service unavailable" }, 503)],
+      async () => {
+        await assert.rejects(
+          () => getCloudClawJwt({ sessionFile }),
+          (error) => {
+            assert.ok(error instanceof Error);
+            assert.match(error.message, /portal-sso is unavailable/);
+            assert.match(error.message, /security rollout/);
+            assert.match(error.message, /auth service unavailable/);
+            return true;
+          }
+        );
+      }
+    );
+  });
+});
+
+test("Cloud Claw command 403 preserves authorization context", async () => {
+  await withSessionFile(async (sessionFile) => {
+    await withFetchResponses(
+      [
+        jsonResponse({ token: "cloud-claw-jwt" }),
+        jsonResponse({ detail: "not allowed for this deployment" }, 403),
+      ],
+      async () => {
+        await assert.rejects(
+          () =>
+            requestCloudClawJson({
+              method: "GET",
+              path: "/api/vm/deployments",
+              sessionFile,
+            }),
+          (error) => {
+            assert.ok(error instanceof Error);
+            assert.match(error.message, /Cloud Claw denied GET \/api\/vm\/deployments/);
+            assert.match(error.message, /HTTP 403/);
+            assert.match(error.message, /not allowed for this deployment/);
+            return true;
+          }
+        );
+      }
+    );
+  });
+});
+
+test("one-shot logs use Cloud Claw authorization guidance", async () => {
+  await withSessionFile(async (sessionFile) => {
+    await withFetchResponses(
+      [
+        jsonResponse({ token: "cloud-claw-jwt" }),
+        jsonResponse({ detail: "paid resource required" }, 403),
+      ],
+      async () => {
+        await assert.rejects(
+          () =>
+            cloudClawLogs({
+              name: "swift-owl-9",
+              sessionFile,
+            }),
+          (error) => {
+            assert.ok(error instanceof Error);
+            assert.match(
+              error.message,
+              /Cloud Claw denied GET \/api\/vm\/deployments\/swift-owl-9\/logs/
+            );
+            assert.match(error.message, /paid resource required/);
+            return true;
+          }
+        );
+      }
+    );
+  });
+});
+
+test("log stream setup uses Cloud Claw auth signing guidance", async () => {
+  await withSessionFile(async (sessionFile) => {
+    await withFetchResponses(
+      [
+        jsonResponse({ token: "cloud-claw-jwt" }),
+        textResponse("jwt invalid", 401),
+      ],
+      async () => {
+        await assert.rejects(
+          () =>
+            cloudClawLogs({
+              name: "swift-owl-9",
+              sessionFile,
+              stream: true,
+            }),
+          (error) => {
+            assert.ok(error instanceof Error);
+            assert.match(error.message, /Cloud Claw rejected the session JWT/);
+            assert.match(error.message, /auth signing may be misconfigured/);
+            assert.match(error.message, /jwt invalid/);
+            return true;
+          }
+        );
+      }
+    );
+  });
+});
+
+test("Cloud Claw JSON success output remains parseable", async () => {
+  await withSessionFile(async (sessionFile) => {
+    const result = await withFetchResponses(
+      [
+        jsonResponse({ token: "cloud-claw-jwt" }),
+        jsonResponse({ deployments: [] }),
+      ],
+      async () =>
+        requestCloudClawJson<{ deployments: unknown[] }>({
+          method: "GET",
+          path: "/api/vm/deployments",
+          baseUrl: CLOUD_CLAW_BASE_URL,
+          sessionFile,
+        })
+    );
+
+    assert.deepEqual(result, { deployments: [] });
+  });
+});

--- a/tests/login-wallet.test.mjs
+++ b/tests/login-wallet.test.mjs
@@ -1,0 +1,304 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import { access, mkdtemp, readFile, rm } from "node:fs/promises";
+import { createServer } from "node:http";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+import test from "node:test";
+
+const execFileAsync = promisify(execFile);
+const cliPath = fileURLToPath(new URL("../dist/cli.js", import.meta.url));
+const walletAddress = "0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266";
+const walletPrivateKey =
+  "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
+const validSignature = `0x${"a".repeat(130)}`;
+const user = {
+  id: "user_123",
+  email: "wallet@example.com",
+  name: "Wallet User",
+};
+
+async function startPortalServer(handler) {
+  const requests = [];
+  const server = createServer(async (request, response) => {
+    let rawBody = "";
+    for await (const chunk of request) {
+      rawBody += chunk;
+    }
+
+    const body = rawBody ? JSON.parse(rawBody) : undefined;
+    const entry = {
+      method: request.method,
+      url: request.url,
+      headers: request.headers,
+      body,
+    };
+    requests.push(entry);
+
+    try {
+      const result = await handler(entry);
+      response.statusCode = result.status ?? 200;
+      response.setHeader("content-type", "application/json");
+      response.end(JSON.stringify(result.json ?? {}));
+    } catch (error) {
+      response.statusCode = 500;
+      response.setHeader("content-type", "application/json");
+      response.end(
+        JSON.stringify({
+          error: error instanceof Error ? error.message : String(error),
+        })
+      );
+    }
+  });
+
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+
+  const address = server.address();
+  assert(address && typeof address === "object");
+
+  return {
+    baseUrl: `http://127.0.0.1:${address.port}`,
+    requests,
+    close: () => new Promise((resolve) => server.close(resolve)),
+  };
+}
+
+async function withTempDir(fn) {
+  const dir = await mkdtemp(join(tmpdir(), "altllm-login-wallet-"));
+  try {
+    return await fn(dir);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+async function runCli(args, env = {}) {
+  return execFileAsync(process.execPath, [cliPath, ...args], {
+    env: {
+      ...process.env,
+      ALTLLM_HTTP_TIMEOUT_MS: "5000",
+      ...env,
+    },
+    timeout: 10_000,
+  });
+}
+
+async function runCliExpectFailure(args, env = {}) {
+  try {
+    await runCli(args, env);
+  } catch (error) {
+    return {
+      code: error.code,
+      stdout: error.stdout,
+      stderr: error.stderr,
+    };
+  }
+
+  assert.fail("Expected CLI command to fail.");
+}
+
+function buildChallengeMessage({ baseUrl, nonce, issuedAt, expiresAt }) {
+  const parsed = new URL(baseUrl);
+
+  return `${parsed.hostname} wants you to sign in with your Ethereum account:
+${walletAddress}
+
+Sign this message to log in to AltLLM Portal.
+
+URI: ${baseUrl}
+Version: 1
+Chain ID: 1
+Nonce: ${nonce}
+Issued At: ${issuedAt}
+Expiration Time: ${expiresAt}`;
+}
+
+test("login-wallet external signature requests an explicit Portal token and saves it", async () => {
+  await withTempDir(async (dir) => {
+    const sessionFile = join(dir, "session.json");
+    const server = await startPortalServer(async (request) => {
+      assert.equal(request.method, "POST");
+      assert.equal(request.url, "/api/auth/crypto/verify");
+
+      return {
+        json: {
+          token: "portal-session-token",
+          user,
+        },
+      };
+    });
+
+    try {
+      const result = await runCli([
+        "login-wallet",
+        "--base-url",
+        server.baseUrl,
+        "--wallet-address",
+        walletAddress,
+        "--nonce",
+        "nonce-external",
+        "--signature",
+        validSignature,
+        "--session-file",
+        sessionFile,
+      ]);
+
+      const output = JSON.parse(result.stdout);
+      assert.equal(output.ok, true);
+      assert.equal(output.sessionFile, sessionFile);
+      assert.deepEqual(output.user, user);
+      assert.equal(output.token, undefined);
+
+      assert.equal(server.requests.length, 1);
+      assert.equal(
+        server.requests[0].headers["x-altllm-return-portal-token"],
+        "1"
+      );
+      assert.deepEqual(server.requests[0].body, {
+        wallet_address: walletAddress,
+        nonce: "nonce-external",
+        signature: validSignature,
+      });
+
+      const savedSession = JSON.parse(await readFile(sessionFile, "utf8"));
+      assert.deepEqual(savedSession, {
+        baseUrl: server.baseUrl,
+        token: "portal-session-token",
+        user,
+      });
+    } finally {
+      await server.close();
+    }
+  });
+});
+
+test("login-wallet fails clearly and does not save a session when token is missing", async () => {
+  await withTempDir(async (dir) => {
+    const sessionFile = join(dir, "session.json");
+    const server = await startPortalServer(async (request) => {
+      assert.equal(request.method, "POST");
+      assert.equal(request.url, "/api/auth/crypto/verify");
+
+      return {
+        json: {
+          user,
+        },
+      };
+    });
+
+    try {
+      const result = await runCliExpectFailure([
+        "login-wallet",
+        "--base-url",
+        server.baseUrl,
+        "--wallet-address",
+        walletAddress,
+        "--nonce",
+        "nonce-missing-token",
+        "--signature",
+        validSignature,
+        "--session-file",
+        sessionFile,
+      ]);
+
+      assert.equal(result.code, 1);
+      assert.match(result.stderr, /did not include a session token/);
+      assert.equal(
+        server.requests[0].headers["x-altllm-return-portal-token"],
+        "1"
+      );
+      await assert.rejects(access(sessionFile));
+    } finally {
+      await server.close();
+    }
+  });
+});
+
+test("login-wallet local signing verify path requests an explicit Portal token", async () => {
+  await withTempDir(async (dir) => {
+    const sessionFile = join(dir, "session.json");
+    const nonce = "nonce-local-signing";
+    const issuedAt = new Date(Date.now() - 60_000).toISOString();
+    const expiresAt = new Date(Date.now() + 3_600_000).toISOString();
+    let baseUrl = "";
+    const server = await startPortalServer(async (request) => {
+      if (request.url === "/api/auth/crypto/challenge") {
+        assert.equal(request.method, "POST");
+        assert.deepEqual(request.body, {
+          wallet_address: walletAddress,
+          chain_id: 1,
+        });
+
+        return {
+          json: {
+            wallet_address: walletAddress,
+            chain_id: 1,
+            nonce,
+            message: buildChallengeMessage({
+              baseUrl,
+              nonce,
+              issuedAt,
+              expiresAt,
+            }),
+            expires_at: expiresAt,
+          },
+        };
+      }
+
+      assert.equal(request.method, "POST");
+      assert.equal(request.url, "/api/auth/crypto/verify");
+      assert.equal(
+        request.headers["x-altllm-return-portal-token"],
+        "1"
+      );
+      assert.equal(request.body.wallet_address, walletAddress);
+      assert.equal(request.body.nonce, nonce);
+      assert.match(request.body.signature, /^0x[a-fA-F0-9]{130}$/);
+
+      return {
+        json: {
+          token: "portal-session-token-local",
+          user,
+        },
+      };
+    });
+    baseUrl = server.baseUrl;
+
+    try {
+      const result = await runCli(
+        [
+          "login-wallet",
+          "--base-url",
+          server.baseUrl,
+          "--wallet-address",
+          walletAddress,
+          "--session-file",
+          sessionFile,
+        ],
+        {
+          ALTLLM_WALLET_PRIVATE_KEY: walletPrivateKey,
+        }
+      );
+
+      const output = JSON.parse(result.stdout);
+      assert.equal(output.ok, true);
+      assert.equal(output.sessionFile, sessionFile);
+      assert.equal(server.requests.length, 2);
+      assert.equal(server.requests[1].url, "/api/auth/crypto/verify");
+
+      const savedSession = JSON.parse(await readFile(sessionFile, "utf8"));
+      assert.equal(savedSession.token, "portal-session-token-local");
+      assert.deepEqual(savedSession.user, user);
+    } finally {
+      await server.close();
+    }
+  });
+});

--- a/tests/security-rollup-contracts.test.ts
+++ b/tests/security-rollup-contracts.test.ts
@@ -1,0 +1,442 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import { privateKeyToAccount } from "viem/accounts";
+
+import { cloudClawLogs } from "../src/commands/cloud-claw-logs.js";
+import { cloudClawMe } from "../src/commands/cloud-claw-me.js";
+import { credit } from "../src/commands/credit.js";
+import { loginWallet } from "../src/commands/login-wallet.js";
+
+type FetchHandler = (
+  url: URL,
+  init: RequestInit
+) => Response | Promise<Response>;
+
+const PORTAL_BASE_URL = "http://127.0.0.1:7040";
+const CLOUD_CLAW_BASE_URL = "http://127.0.0.1:7041";
+const WALLET_ADDRESS = "0x1111111111111111111111111111111111111111";
+const EXTERNAL_SIGNATURE = `0x${"a".repeat(130)}`;
+const TEST_PRIVATE_KEY =
+  "0x1111111111111111111111111111111111111111111111111111111111111111";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      "content-type": "application/json",
+    },
+  });
+}
+
+function textResponse(body: string, status = 200): Response {
+  return new Response(body, { status });
+}
+
+async function createTempSessionPath(t: test.TestContext): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "altllm-cli-"));
+  t.after(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+  return join(dir, "session.json");
+}
+
+async function writePortalSession(
+  sessionFile: string,
+  token = "portal-session-token"
+): Promise<void> {
+  await writeFile(
+    sessionFile,
+    JSON.stringify({
+      baseUrl: PORTAL_BASE_URL,
+      token,
+      user: {
+        id: "user-1",
+        email: "user@example.test",
+      },
+    })
+  );
+}
+
+function captureStdout(t: test.TestContext): () => string {
+  const originalWrite = process.stdout.write;
+  let output = "";
+
+  process.stdout.write = ((chunk: unknown, encoding?: unknown, cb?: unknown) => {
+    output += Buffer.isBuffer(chunk) ? chunk.toString() : String(chunk);
+    if (typeof encoding === "function") {
+      encoding();
+    }
+    if (typeof cb === "function") {
+      cb();
+    }
+    return true;
+  }) as typeof process.stdout.write;
+
+  t.after(() => {
+    process.stdout.write = originalWrite;
+  });
+
+  return () => output;
+}
+
+function mockFetch(t: test.TestContext, handler: FetchHandler): void {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (async (input: RequestInfo | URL, init: RequestInit = {}) => {
+    const url =
+      input instanceof Request ? new URL(input.url) : new URL(String(input));
+    return handler(url, init);
+  }) as typeof fetch;
+
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+  });
+}
+
+function requestHeaders(init: RequestInit): Headers {
+  return new Headers(init.headers);
+}
+
+function requestBody(init: RequestInit): Record<string, unknown> {
+  assert.equal(typeof init.body, "string");
+  return JSON.parse(init.body as string);
+}
+
+function buildChallengeMessage(params: {
+  walletAddress: string;
+  nonce: string;
+  expiresAt: string;
+}): string {
+  const issuedAt = new Date(Date.now() - 1_000).toISOString();
+  return `localhost wants you to sign in with your Ethereum account:
+${params.walletAddress}
+
+Sign this message to log in to AltLLM Portal.
+
+URI: http://localhost:7040/
+Version: 1
+Chain ID: 1
+Nonce: ${params.nonce}
+Issued At: ${issuedAt}
+Expiration Time: ${params.expiresAt}`;
+}
+
+test("security rollup: external wallet verify opts into Portal token and saves it", async (t) => {
+  const sessionFile = await createTempSessionPath(t);
+
+  mockFetch(t, (url, init) => {
+    assert.equal(url.href, `${PORTAL_BASE_URL}/api/auth/crypto/verify`);
+    assert.equal(init.method, "POST");
+    assert.equal(
+      requestHeaders(init).get("x-altllm-return-portal-token"),
+      "1"
+    );
+    assert.deepEqual(requestBody(init), {
+      wallet_address: WALLET_ADDRESS,
+      nonce: "nonce-1",
+      signature: EXTERNAL_SIGNATURE,
+    });
+
+    return jsonResponse({
+      token: "new-portal-token",
+      user: {
+        id: "user-1",
+        email: "user@example.test",
+      },
+    });
+  });
+
+  captureStdout(t);
+  await loginWallet({
+    baseUrl: PORTAL_BASE_URL,
+    walletAddress: WALLET_ADDRESS,
+    privateKeyEnv: "ALTLLM_WALLET_PRIVATE_KEY",
+    chainId: 1,
+    nonce: "nonce-1",
+    signature: EXTERNAL_SIGNATURE,
+    sessionFile,
+  });
+
+  const session = JSON.parse(await readFile(sessionFile, "utf8"));
+  assert.equal(session.token, "new-portal-token");
+});
+
+test("security rollup: local wallet verify also opts into Portal token", async (t) => {
+  const sessionFile = await createTempSessionPath(t);
+  const account = privateKeyToAccount(TEST_PRIVATE_KEY);
+  const nonce = "local-nonce";
+  const expiresAt = new Date(Date.now() + 60_000).toISOString();
+  let challengeRequested = false;
+  let verifyRequested = false;
+
+  mockFetch(t, (url, init) => {
+    if (url.pathname === "/api/auth/crypto/challenge") {
+      challengeRequested = true;
+      assert.equal(init.method, "POST");
+      assert.deepEqual(requestBody(init), {
+        wallet_address: account.address,
+        chain_id: 1,
+      });
+
+      return jsonResponse({
+        wallet_address: account.address,
+        chain_id: 1,
+        nonce,
+        message: buildChallengeMessage({
+          walletAddress: account.address,
+          nonce,
+          expiresAt,
+        }),
+        expires_at: expiresAt,
+      });
+    }
+
+    assert.equal(url.pathname, "/api/auth/crypto/verify");
+    verifyRequested = true;
+    assert.equal(
+      requestHeaders(init).get("x-altllm-return-portal-token"),
+      "1"
+    );
+    const body = requestBody(init);
+    assert.equal(body.wallet_address, account.address);
+    assert.equal(body.nonce, nonce);
+    assert.match(String(body.signature), /^0x[a-fA-F0-9]+$/);
+
+    return jsonResponse({
+      token: "local-portal-token",
+      user: {
+        id: "user-2",
+        email: "local@example.test",
+      },
+    });
+  });
+
+  captureStdout(t);
+  await loginWallet({
+    baseUrl: "http://localhost:7040",
+    walletAddress: account.address,
+    privateKey: TEST_PRIVATE_KEY,
+    privateKeyEnv: "ALTLLM_WALLET_PRIVATE_KEY",
+    allowUnsafePrivateKeyArgv: true,
+    chainId: 1,
+    sessionFile,
+  });
+
+  assert.equal(challengeRequested, true);
+  assert.equal(verifyRequested, true);
+  const session = JSON.parse(await readFile(sessionFile, "utf8"));
+  assert.equal(session.token, "local-portal-token");
+});
+
+test("security rollup: wallet verify without token fails before writing a session", async (t) => {
+  const sessionFile = await createTempSessionPath(t);
+
+  mockFetch(t, () =>
+    jsonResponse({
+      user: {
+        id: "user-1",
+        email: "user@example.test",
+      },
+    })
+  );
+
+  await assert.rejects(
+    loginWallet({
+      baseUrl: PORTAL_BASE_URL,
+      walletAddress: WALLET_ADDRESS,
+      privateKeyEnv: "ALTLLM_WALLET_PRIVATE_KEY",
+      chainId: 1,
+      nonce: "nonce-1",
+      signature: EXTERNAL_SIGNATURE,
+      sessionFile,
+    }),
+    /did not include a session token/
+  );
+  await assert.rejects(readFile(sessionFile, "utf8"), /ENOENT/);
+});
+
+test("security rollup: saved Portal session 401 gives re-login guidance", async (t) => {
+  const sessionFile = await createTempSessionPath(t);
+  await writePortalSession(sessionFile, "stale-portal-token");
+
+  mockFetch(t, (url, init) => {
+    assert.equal(url.href, `${PORTAL_BASE_URL}/api/billing/balance`);
+    assert.equal(requestHeaders(init).get("authorization"), "Bearer stale-portal-token");
+    return textResponse("expired", 401);
+  });
+
+  await assert.rejects(
+    credit({
+      sessionFile,
+    }),
+    /Saved Portal session was rejected.*login-wallet/
+  );
+});
+
+test("security rollup: Cloud Claw SSO success uses bearer JWT for JSON command", async (t) => {
+  const sessionFile = await createTempSessionPath(t);
+  await writePortalSession(sessionFile);
+  const stdout = captureStdout(t);
+
+  mockFetch(t, (url, init) => {
+    if (url.pathname === "/api/auth/portal-sso") {
+      assert.equal(init.method, "POST");
+      assert.deepEqual(requestBody(init), {
+        token: "portal-session-token",
+        force: false,
+      });
+      return jsonResponse({
+        authenticated: true,
+        token: "cloud-claw-jwt",
+      });
+    }
+
+    assert.equal(url.href, `${CLOUD_CLAW_BASE_URL}/api/auth/me`);
+    assert.equal(requestHeaders(init).get("authorization"), "Bearer cloud-claw-jwt");
+    return jsonResponse({
+      id: "cloud-user",
+    });
+  });
+
+  await cloudClawMe({
+    baseUrl: CLOUD_CLAW_BASE_URL,
+    sessionFile,
+    allowTokenForwarding: true,
+  });
+
+  assert.deepEqual(JSON.parse(stdout()), {
+    id: "cloud-user",
+  });
+});
+
+test("security rollup: Cloud Claw SSO 401 points users to re-login", async (t) => {
+  const sessionFile = await createTempSessionPath(t);
+  await writePortalSession(sessionFile, "stale-portal-token");
+
+  mockFetch(t, (url) => {
+    assert.equal(url.pathname, "/api/auth/portal-sso");
+    return textResponse("stale portal token", 401);
+  });
+
+  await assert.rejects(
+    cloudClawMe({
+      baseUrl: CLOUD_CLAW_BASE_URL,
+      sessionFile,
+      allowTokenForwarding: true,
+    }),
+    /portal-sso rejected the saved Portal session.*login-wallet/
+  );
+});
+
+test("security rollup: Cloud Claw SSO 503 surfaces readiness guidance", async (t) => {
+  const sessionFile = await createTempSessionPath(t);
+  await writePortalSession(sessionFile);
+
+  mockFetch(t, (url) => {
+    assert.equal(url.pathname, "/api/auth/portal-sso");
+    return textResponse("auth config unavailable", 503);
+  });
+
+  await assert.rejects(
+    cloudClawMe({
+      baseUrl: CLOUD_CLAW_BASE_URL,
+      sessionFile,
+      allowTokenForwarding: true,
+    }),
+    /portal-sso is unavailable.*security rollout/
+  );
+});
+
+test("security rollup: Cloud Claw logs use bearer JWT", async (t) => {
+  const sessionFile = await createTempSessionPath(t);
+  await writePortalSession(sessionFile);
+  const stdout = captureStdout(t);
+
+  mockFetch(t, (url, init) => {
+    if (url.pathname === "/api/auth/portal-sso") {
+      return jsonResponse({
+        token: "cloud-claw-jwt",
+      });
+    }
+
+    assert.equal(url.href, `${CLOUD_CLAW_BASE_URL}/api/vm/deployments/demo/logs`);
+    assert.equal(requestHeaders(init).get("authorization"), "Bearer cloud-claw-jwt");
+    return textResponse("ready");
+  });
+
+  await cloudClawLogs({
+    name: "demo",
+    baseUrl: CLOUD_CLAW_BASE_URL,
+    sessionFile,
+    allowTokenForwarding: true,
+  });
+
+  assert.equal(stdout(), "ready\n");
+});
+
+test("security rollup: Cloud Claw stream logs use bearer JWT", async (t) => {
+  const sessionFile = await createTempSessionPath(t);
+  await writePortalSession(sessionFile);
+  const stdout = captureStdout(t);
+
+  mockFetch(t, (url, init) => {
+    if (url.pathname === "/api/auth/portal-sso") {
+      return jsonResponse({
+        token: "cloud-claw-jwt",
+      });
+    }
+
+    assert.equal(
+      url.href,
+      `${CLOUD_CLAW_BASE_URL}/api/vm/deployments/demo/logs/stream`
+    );
+    assert.equal(requestHeaders(init).get("authorization"), "Bearer cloud-claw-jwt");
+    return new Response(
+      new ReadableStream({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode("data: ready\n\n"));
+          controller.close();
+        },
+      }),
+      { status: 200 }
+    );
+  });
+
+  await cloudClawLogs({
+    name: "demo",
+    baseUrl: CLOUD_CLAW_BASE_URL,
+    sessionFile,
+    allowTokenForwarding: true,
+    stream: true,
+  });
+
+  assert.equal(stdout(), "data: ready\n\n");
+});
+
+test("security rollup: Cloud Claw log 403 keeps authorization guidance", async (t) => {
+  const sessionFile = await createTempSessionPath(t);
+  await writePortalSession(sessionFile);
+
+  mockFetch(t, (url) => {
+    if (url.pathname === "/api/auth/portal-sso") {
+      return jsonResponse({
+        token: "cloud-claw-jwt",
+      });
+    }
+
+    return textResponse("deployment access denied", 403);
+  });
+
+  await assert.rejects(
+    cloudClawLogs({
+      name: "demo",
+      baseUrl: CLOUD_CLAW_BASE_URL,
+      sessionFile,
+      allowTokenForwarding: true,
+    }),
+    /Cloud Claw denied GET \/api\/vm\/deployments\/demo\/logs.*authorized/
+  );
+});

--- a/tests/security-rollup-contracts.test.ts
+++ b/tests/security-rollup-contracts.test.ts
@@ -377,7 +377,7 @@ test("security rollup: Cloud Claw logs use bearer JWT", async (t) => {
   assert.equal(stdout(), "ready\n");
 });
 
-test("security rollup: Cloud Claw stream logs use bearer JWT", async (t) => {
+test("security rollup: Cloud Claw stream logs use auth query JWT", async (t) => {
   const sessionFile = await createTempSessionPath(t);
   await writePortalSession(sessionFile);
   const stdout = captureStdout(t);
@@ -391,9 +391,9 @@ test("security rollup: Cloud Claw stream logs use bearer JWT", async (t) => {
 
     assert.equal(
       url.href,
-      `${CLOUD_CLAW_BASE_URL}/api/vm/deployments/demo/logs/stream`
+      `${CLOUD_CLAW_BASE_URL}/api/vm/deployments/demo/logs/stream?auth=cloud-claw-jwt`
     );
-    assert.equal(requestHeaders(init).get("authorization"), "Bearer cloud-claw-jwt");
+    assert.equal(requestHeaders(init).get("authorization"), null);
     return new Response(
       new ReadableStream({
         start(controller) {

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": ["src/**/*.ts", "tests/**/*.ts"]
+}

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -4,5 +4,5 @@
     "noEmit": true,
     "rootDir": "."
   },
-  "include": ["src/**/*.ts", "tests/**/*.ts"]
+  "include": ["src/**/*.ts", "test/**/*.ts", "tests/**/*.ts"]
 }


### PR DESCRIPTION
## Summary

- Merge Portal session trust-domain and stale-session compatibility fixes.
- Add explicit Portal token request handling for wallet login.
- Normalize Cloud Claw portal-sso and authorization failures.
- Add mocked regression coverage for the security rollout contracts and wire test TypeScript checks into `npm run typecheck`.

Closes #59
Closes #60
Closes #61
Closes #62
Closes #63
Closes #64

## Validation

- Validation was run on the child PRs while developing the fixes.
- Release validation should be rerun on this PR before merge: `npm install`, `npm run typecheck`, `npm run build`, `npm test`.