### PR TITLE
Add Portal CLI staging/prod E2E test plan

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist/
 .env
 .env.*
 *.env
+.altllm-e2e/

--- a/docs/portal-cli-staging-prod-test-plan.md
+++ b/docs/portal-cli-staging-prod-test-plan.md
@@ -1,0 +1,198 @@
+# Portal CLI Staging And Production Test Plan
+
+This plan validates the `altllm` CLI against the AltLLM Portal API with four wallet-backed users. It covers full functional testing in staging and controlled smoke testing in production.
+
+## Secret Handling
+
+Do not commit private keys, Portal session files, `.env` files, or generated wallet material.
+
+Allowed in git:
+
+- this test plan
+- scripts that generate local wallets
+- public wallet addresses when useful for coordination
+- GitHub encrypted secret names
+
+Not allowed in git:
+
+- raw private keys
+- `wallets.private.json`
+- `*.session.json`
+- funded-wallet details beyond public addresses
+
+If GitHub storage is needed, use GitHub encrypted secrets, not committed files. Suggested secret names:
+
+- `ALTLLM_STAGING_E2E_USER_1_PRIVATE_KEY`
+- `ALTLLM_STAGING_E2E_USER_2_PRIVATE_KEY`
+- `ALTLLM_STAGING_E2E_USER_3_PRIVATE_KEY`
+- `ALTLLM_STAGING_E2E_USER_4_PRIVATE_KEY`
+- `ALTLLM_PROD_E2E_USER_1_PRIVATE_KEY`
+- `ALTLLM_PROD_E2E_USER_2_PRIVATE_KEY`
+- `ALTLLM_PROD_E2E_USER_3_PRIVATE_KEY`
+- `ALTLLM_PROD_E2E_USER_4_PRIVATE_KEY`
+
+Keep production test wallets unfunded unless a real direct-payment smoke test is explicitly approved.
+
+## Account Preparation
+
+Generate four staging wallets:
+
+```bash
+npm run prepare:test-wallets -- \
+  --out-dir .altllm-e2e/staging \
+  --prefix staging-user \
+  --secret-prefix ALTLLM_STAGING_E2E_USER
+```
+
+Generate four production wallets separately:
+
+```bash
+npm run prepare:test-wallets -- \
+  --out-dir .altllm-e2e/prod \
+  --prefix prod-user \
+  --secret-prefix ALTLLM_PROD_E2E_USER
+```
+
+Generated files:
+
+- `wallets.private.json`: local private keys, mode `0600`, never committed
+- `wallets.public.json`: public addresses, env var names, and session-file paths
+- `login-commands.sh`: login commands that read private keys from env vars
+- `github-secrets-template.sh`: optional helper for setting GitHub encrypted secrets from exported env vars
+
+The prepared public account registry is tracked in `docs/portal-cli-test-accounts.public.json`. It contains only wallet addresses and matching secret names. The private keys for those addresses must stay in local `.altllm-e2e/**/wallets.private.json` files or GitHub encrypted secrets.
+
+To create Portal users, export the private keys, set the target URL, then run the generated login commands:
+
+```bash
+export ALTLLM_E2E_BASE_URL=https://staging-platform-api.example.com
+export ALTLLM_STAGING_E2E_USER_1_PRIVATE_KEY=0x...
+export ALTLLM_STAGING_E2E_USER_2_PRIVATE_KEY=0x...
+export ALTLLM_STAGING_E2E_USER_3_PRIVATE_KEY=0x...
+export ALTLLM_STAGING_E2E_USER_4_PRIVATE_KEY=0x...
+bash .altllm-e2e/staging/login-commands.sh
+```
+
+Production uses `https://platform-api.altllm.ai`, but run production only as a smoke test unless stress testing is explicitly approved.
+
+## Environment Matrix
+
+Staging should run the full suite:
+
+- wallet login for four users
+- all read commands
+- API key create/get/update/revoke
+- payment-link creation
+- discount-code preview and guardrails when testing the payment-discount branch
+- concurrency and stress tests
+
+Production should run smoke tests only:
+
+- wallet login for four test users
+- read commands
+- API key create/get/update/revoke
+- a small number of payment-link creations
+- discount-code preview behavior when testing the payment-discount branch
+
+Do not run production stress, mass payment-link creation, or real on-chain payment without explicit approval.
+
+## Functional Test Matrix
+
+Run these commands per user with that user's session file:
+
+```bash
+node dist/cli.js credit --base-url "$BASE_URL" --session-file "$SESSION"
+node dist/cli.js transactions --base-url "$BASE_URL" --session-file "$SESSION"
+node dist/cli.js usage-summary --base-url "$BASE_URL" --session-file "$SESSION"
+node dist/cli.js usage-timeline --base-url "$BASE_URL" --session-file "$SESSION"
+node dist/cli.js usage-by-model --base-url "$BASE_URL" --session-file "$SESSION"
+node dist/cli.js usage-by-key --base-url "$BASE_URL" --session-file "$SESSION"
+node dist/cli.js list-api-keys --base-url "$BASE_URL" --session-file "$SESSION"
+```
+
+API key lifecycle:
+
+```bash
+KEY_JSON="$(node dist/cli.js create-api-key --name e2e-smoke --base-url "$BASE_URL" --session-file "$SESSION")"
+KEY_ID="$(printf '%s' "$KEY_JSON" | node -e 'let data=\"\"; process.stdin.on(\"data\", c => data += c); process.stdin.on(\"end\", () => console.log(JSON.parse(data).id));')"
+node dist/cli.js get-api-key --key-id "$KEY_ID" --base-url "$BASE_URL" --session-file "$SESSION"
+node dist/cli.js update-api-key --key-id "$KEY_ID" --name e2e-smoke-updated --base-url "$BASE_URL" --session-file "$SESSION"
+node dist/cli.js revoke-api-key --key-id "$KEY_ID" --base-url "$BASE_URL" --session-file "$SESSION"
+```
+
+Payment-link smoke tests:
+
+```bash
+node dist/cli.js topup-crypto --amount 5 --base-url "$BASE_URL" --session-file "$SESSION"
+```
+
+Additional payment-discount branch smoke tests:
+
+```bash
+node dist/cli.js topup-crypto --amount 5 --discount-code SOLANA --base-url "$BASE_URL" --session-file "$SESSION"
+node dist/cli.js topup-crypto --amount 5 --discount-code SOLANA --pay-currency sol --base-url "$BASE_URL" --session-file "$SESSION"
+```
+
+Expected payment-discount branch behavior:
+
+- single-token discount auto-resolves its pay currency before payment-link creation
+- matching explicit `--pay-currency` succeeds
+- mismatched explicit `--pay-currency` fails before payment-link creation
+- multi-token discounts without `--pay-currency` fail with valid choices
+- missing or empty `allowed_pay_currencies` fails before payment-link creation
+
+## Stress Test Scope
+
+Stress only staging by default.
+
+Safe stress scenarios:
+
+- concurrent `credit`
+- concurrent `transactions`
+- concurrent `usage-*`
+- concurrent `list-api-keys`
+- create/update/revoke API keys with unique names
+- discount-code preview and fail-fast paths when testing the payment-discount branch
+- limited payment-link creation if the provider/invoice volume is approved
+
+Avoid in stress:
+
+- `topup-crypto --auto-pay`
+- `pay-payment-link`
+- funded production wallets
+- production stress without explicit approval
+
+Suggested concurrency levels:
+
+- 4 users x 5 concurrent commands
+- 4 users x 25 concurrent commands
+- 4 users x 100 total iterations
+
+Collect:
+
+- success/failure count
+- p50/p95/p99 latency
+- non-JSON output count
+- HTTP 4xx/5xx breakdown
+- rate-limit responses
+- whether any command leaks private key or session data
+
+## Funds Policy
+
+Wallet users do not need funds for login, read commands, API key commands, or hosted payment-link creation.
+
+Funds are needed only for commands that send on-chain transactions:
+
+- `topup-crypto --auto-pay`
+- `pay-payment-link`
+
+Run real direct payment only as a separate tiny smoke test with one funded wallet, one known supported network/token, and explicit approval.
+
+## Acceptance Criteria
+
+- all command outputs are valid JSON on success
+- failures are clear and do not create unsafe side effects
+- user isolation holds across all four sessions
+- no private key or session content appears in logs, git, PR comments, or command output
+- staging stress has no unexplained 5xx errors
+- production smoke has no unexpected payment-provider side effects

--- a/docs/portal-cli-test-accounts.public.json
+++ b/docs/portal-cli-test-accounts.public.json
@@ -1,0 +1,48 @@
+{
+  "warning": "Public wallet addresses only. Private keys are not stored in git; use local .altllm-e2e files or GitHub encrypted secrets.",
+  "createdFor": "Portal CLI staging/prod validation",
+  "staging": [
+    {
+      "name": "staging-user1",
+      "address": "0x41AC65C04cC9a9f7ae1A4BBB6D5Ba3CFC3D9cBdb",
+      "privateKeySecret": "ALTLLM_STAGING_E2E_USER_1_PRIVATE_KEY"
+    },
+    {
+      "name": "staging-user2",
+      "address": "0xaA51aC92DC4437c285F86192c31581CdBbad53f1",
+      "privateKeySecret": "ALTLLM_STAGING_E2E_USER_2_PRIVATE_KEY"
+    },
+    {
+      "name": "staging-user3",
+      "address": "0x49013b4A1D44CBca508F4D1e81d4f339cE7E7cC1",
+      "privateKeySecret": "ALTLLM_STAGING_E2E_USER_3_PRIVATE_KEY"
+    },
+    {
+      "name": "staging-user4",
+      "address": "0xdD07D8A25E3FCeA9267b8b4B2C481bf23CE36A12",
+      "privateKeySecret": "ALTLLM_STAGING_E2E_USER_4_PRIVATE_KEY"
+    }
+  ],
+  "prod": [
+    {
+      "name": "prod-user1",
+      "address": "0xdA591B615Ca2eB0f4739E8be5A4a950472440aE7",
+      "privateKeySecret": "ALTLLM_PROD_E2E_USER_1_PRIVATE_KEY"
+    },
+    {
+      "name": "prod-user2",
+      "address": "0x80A4ec83D1A07bC1E7a5cfA99a9747A32416Dd8a",
+      "privateKeySecret": "ALTLLM_PROD_E2E_USER_2_PRIVATE_KEY"
+    },
+    {
+      "name": "prod-user3",
+      "address": "0x7aD96CE936917Cf227cE462E7B3114F217E03Db8",
+      "privateKeySecret": "ALTLLM_PROD_E2E_USER_3_PRIVATE_KEY"
+    },
+    {
+      "name": "prod-user4",
+      "address": "0xAc17909f04b3dF0c7F66161b59Daa60EE1281927",
+      "privateKeySecret": "ALTLLM_PROD_E2E_USER_4_PRIVATE_KEY"
+    }
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -679,9 +679,9 @@
       }
     },
     "node_modules/ox": {
-      "version": "0.14.7",
-      "resolved": "https://registry.npmjs.org/ox/-/ox-0.14.7.tgz",
-      "integrity": "sha512-zSQ/cfBdolj7U4++NAvH7sI+VG0T3pEohITCgcQj8KlawvTDY4vGVhDT64Atsm0d6adWfIYHDpu88iUBMMp+AQ==",
+      "version": "0.14.22",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.14.22.tgz",
+      "integrity": "sha512-nb5msL8qWbPglhIfZbGJAfw3cqiJjFMiWmACt7kgyWtLib12tcctbHufMT9Hb0Lr6Pt4k9I3dbpueTpbhvbqvA==",
       "funding": [
         {
           "type": "github",
@@ -760,9 +760,9 @@
       "license": "MIT"
     },
     "node_modules/viem": {
-      "version": "2.47.6",
-      "resolved": "https://registry.npmjs.org/viem/-/viem-2.47.6.tgz",
-      "integrity": "sha512-zExmbI99NGvMdYa7fmqSTLgkwh48dmhgEqFrUgkpL4kfG4XkVefZ8dZqIKVUhZo6Uhf0FrrEXOsHm9LUyIvI2Q==",
+      "version": "2.50.4",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-2.50.4.tgz",
+      "integrity": "sha512-rf98F4s3Vlb+uJZEKfay3IbBw3CNCbVtx5Y3UIljlO2tSX420g/J0WQSYsjzBSasUFgxgsXabji14O9kGbiqgg==",
       "funding": [
         {
           "type": "github",
@@ -777,8 +777,8 @@
         "@scure/bip39": "1.6.0",
         "abitype": "1.2.3",
         "isows": "1.0.7",
-        "ox": "0.14.7",
-        "ws": "8.18.3"
+        "ox": "0.14.22",
+        "ws": "8.20.1"
       },
       "peerDependencies": {
         "typescript": ">=5.0.4"
@@ -790,9 +790,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.18.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "dev": "tsx src/cli.ts",
+    "prepare:test-wallets": "node scripts/prepare-test-wallets.mjs",
     "typecheck": "tsc --noEmit"
   },
   "repository": {

--- a/scripts/prepare-test-wallets.mjs
+++ b/scripts/prepare-test-wallets.mjs
@@ -1,0 +1,197 @@
+#!/usr/bin/env node
+import { chmod, mkdir, rm, writeFile } from "node:fs/promises";
+import { resolve } from "node:path";
+
+import { generatePrivateKey, privateKeyToAccount } from "viem/accounts";
+
+function parseArgs(argv) {
+  const options = {
+    count: 4,
+    outDir: ".altllm-e2e/wallets",
+    prefix: "user",
+    secretPrefix: "ALTLLM_E2E_USER",
+    force: false,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    const next = () => {
+      const value = argv[index + 1];
+      if (!value || value.startsWith("--")) {
+        throw new Error(`${arg} requires a value`);
+      }
+      index += 1;
+      return value;
+    };
+
+    if (arg === "--count") {
+      const count = Number(next());
+      if (!Number.isInteger(count) || count <= 0) {
+        throw new Error("--count must be a positive integer");
+      }
+      options.count = count;
+    } else if (arg === "--out-dir") {
+      options.outDir = next();
+    } else if (arg === "--prefix") {
+      options.prefix = next();
+    } else if (arg === "--secret-prefix") {
+      options.secretPrefix = next();
+    } else if (arg === "--force") {
+      options.force = true;
+    } else if (arg === "--help" || arg === "-h") {
+      process.stdout.write(`Usage: node scripts/prepare-test-wallets.mjs [options]
+
+Options:
+  --count <n>              Number of wallets to generate (default: 4)
+  --out-dir <path>         Output directory (default: .altllm-e2e/wallets)
+  --prefix <name>          Public test-account name prefix (default: user)
+  --secret-prefix <name>   Environment/GitHub secret prefix (default: ALTLLM_E2E_USER)
+  --force                  Overwrite existing output files
+  -h, --help               Show help
+
+Private keys are written only under the output directory, which is gitignored.
+Do not commit wallets.private.json.
+`);
+      process.exit(0);
+    } else {
+      throw new Error(`Unknown option: ${arg}`);
+    }
+  }
+
+  return options;
+}
+
+async function writeJson(path, payload, mode) {
+  await writeFile(path, `${JSON.stringify(payload, null, 2)}\n`, {
+    encoding: "utf8",
+    flag: "wx",
+    mode,
+  });
+  await chmod(path, mode);
+}
+
+async function writeText(path, text, mode) {
+  await writeFile(path, text, {
+    encoding: "utf8",
+    flag: "wx",
+    mode,
+  });
+  await chmod(path, mode);
+}
+
+function shellQuote(value) {
+  return `'${value.replaceAll("'", "'\\''")}'`;
+}
+
+async function main() {
+  const options = parseArgs(process.argv.slice(2));
+  const outDir = resolve(options.outDir);
+  await mkdir(outDir, { recursive: true, mode: 0o700 });
+  await mkdir(resolve(outDir, "sessions"), { recursive: true, mode: 0o700 });
+
+  const users = Array.from({ length: options.count }, (_, index) => {
+    const privateKey = generatePrivateKey();
+    const account = privateKeyToAccount(privateKey);
+    const number = index + 1;
+    const name = `${options.prefix}${number}`;
+    const privateKeyEnv = `${options.secretPrefix}_${number}_PRIVATE_KEY`;
+    const sessionFile = `${outDir}/sessions/${name}.session.json`;
+
+    return {
+      name,
+      address: account.address,
+      privateKey,
+      privateKeyEnv,
+      sessionFile,
+    };
+  });
+
+  const generatedAt = new Date().toISOString();
+  const privatePayload = {
+    generatedAt,
+    warning:
+      "Sensitive local test-wallet material. Do not commit, paste into issues, or print in CI logs.",
+    users,
+  };
+  const publicPayload = {
+    generatedAt,
+    note:
+      "Public wallet addresses and secret names only. Store private keys in local env vars or GitHub encrypted secrets, not in git.",
+    users: users.map(({ privateKey, ...publicUser }) => publicUser),
+  };
+
+  const loginLines = [
+    "#!/usr/bin/env bash",
+    "set -euo pipefail",
+    "",
+    'BASE_URL="${ALTLLM_E2E_BASE_URL:?set ALTLLM_E2E_BASE_URL to the Portal API target}"',
+    'CLI="${ALTLLM_E2E_CLI:-node dist/cli.js}"',
+    "",
+  ];
+  for (const user of users) {
+    loginLines.push(
+      `ALTLLM_WALLET_PRIVATE_KEY="\${${user.privateKeyEnv}:?set ${user.privateKeyEnv}}" \\`,
+      '  "$CLI" login-wallet \\',
+      '    --base-url "$BASE_URL" \\',
+      `    --wallet-address ${shellQuote(user.address)} \\`,
+      `    --session-file ${shellQuote(user.sessionFile)}`,
+      ""
+    );
+  }
+
+  const secretLines = [
+    "#!/usr/bin/env bash",
+    "set -euo pipefail",
+    "",
+    'REPO="${GITHUB_REPOSITORY:-alt-research/altllm-skills}"',
+    "",
+    "# Export each private key in your shell first, then run this script.",
+    "# Example: export ALTLLM_E2E_USER_1_PRIVATE_KEY=0x...",
+    "",
+  ];
+  for (const user of users) {
+    secretLines.push(
+      `printf '%s' "\${${user.privateKeyEnv}:?set ${user.privateKeyEnv}}" | gh secret set ${user.privateKeyEnv} --repo "$REPO"`
+    );
+  }
+  secretLines.push("");
+
+  const privatePath = resolve(outDir, "wallets.private.json");
+  const publicPath = resolve(outDir, "wallets.public.json");
+  const loginPath = resolve(outDir, "login-commands.sh");
+  const secretsPath = resolve(outDir, "github-secrets-template.sh");
+
+  if (options.force) {
+    await Promise.all(
+      [privatePath, publicPath, loginPath, secretsPath].map((path) =>
+        rm(path, { force: true })
+      )
+    );
+  }
+
+  await writeJson(privatePath, privatePayload, 0o600);
+  await writeJson(publicPath, publicPayload, 0o644);
+  await writeText(loginPath, `${loginLines.join("\n")}\n`, 0o700);
+  await writeText(secretsPath, `${secretLines.join("\n")}\n`, 0o700);
+
+  process.stdout.write(
+    `${JSON.stringify(
+      {
+        outDir,
+        publicFile: publicPath,
+        privateFile: privatePath,
+        loginCommands: loginPath,
+        githubSecretsTemplate: secretsPath,
+        users: publicPayload.users,
+      },
+      null,
+      2
+    )}\n`
+  );
+}
+
+main().catch((error) => {
+  const message = error instanceof Error ? error.message : String(error);
+  process.stderr.write(`error: ${message}\n`);
+  process.exit(1);
+});

--- a/src/commands/login-wallet.ts
+++ b/src/commands/login-wallet.ts
@@ -4,6 +4,7 @@ import {
   normalizeWalletSignature,
   resolvePrivateKey,
   signChallengeMessage,
+  validateUnsafePrivateKeyArgvUsage,
 } from "../lib/wallet.js";
 
 interface CryptoChallengeResponse {


### PR DESCRIPTION
## Summary

Adds a staging/prod validation plan for the Portal CLI and a safe wallet-prep workflow for creating four wallet-backed users per environment.

## What changed

- Added `docs/portal-cli-staging-prod-test-plan.md` with:
  - staging full-test scope
  - production smoke-test scope
  - funds policy
  - stress-test boundaries
  - command matrix for login, billing, usage, API keys, payment links, and payment-discount branch checks
- Added `scripts/prepare-test-wallets.mjs` and `npm run prepare:test-wallets` to generate local test wallets.
- Added `docs/portal-cli-test-accounts.public.json` with public-only staging/prod wallet addresses and matching GitHub secret names.
- Added `.altllm-e2e/` to `.gitignore` so generated private keys/session files stay local.
- Fixed a missing `validateUnsafePrivateKeyArgvUsage` import in `login-wallet.ts`, which was causing `npm run typecheck` / `npm run build` to fail from `main`.
- Refreshed the lockfile with `npm audit fix` so `viem` resolves to `2.50.4` / `ws` `8.20.1` and the audit is clean.

## Secret handling

No private keys or session files are committed.

Generated private keys are local-only under `.altllm-e2e/**/wallets.private.json`. The PR stores only public wallet addresses and secret names. If we store private keys in GitHub, they should go into GitHub encrypted secrets such as `ALTLLM_STAGING_E2E_USER_1_PRIVATE_KEY`, not into git.

## Local account prep completed

Generated local wallet artifacts for:

- `.altllm-e2e/staging`
- `.altllm-e2e/prod`

Those paths are gitignored. The committed public registry maps the public addresses to the secret names.

## Validation

- `npm run prepare:test-wallets -- --out-dir .altllm-e2e/staging --prefix staging-user --secret-prefix ALTLLM_STAGING_E2E_USER`: passed
- `npm run prepare:test-wallets -- --out-dir .altllm-e2e/prod --prefix prod-user --secret-prefix ALTLLM_PROD_E2E_USER`: passed
- `npm run prepare:test-wallets -- --out-dir /tmp/altllm-wallet-script-check-2 --prefix check-user --secret-prefix ALTLLM_CHECK_USER --force`: passed
- public account registry JSON parse: passed
- staged diff private-key scan: no raw private-key material found
- `npm run typecheck`: passed
- `npm run build`: passed
- `npm audit --audit-level=low`: 0 vulnerabilities
- `npm audit signatures`: 48 registry signatures verified, 37 attestations verified
- `npm ls --depth=0`: clean top-level dependency tree
- `git diff --check`: passed
