### PR TITLE
feat(cli): add version flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,12 +254,22 @@ node dist/cli.js logout
 
 Use `ALTLLM_WALLET_PRIVATE_KEY` instead of passing `--private-key` inline whenever possible.
 
-Safer local private-key input paths:
+Local private-key input options:
 
+- `ALTLLM_WALLET_PRIVATE_KEY=<private-key>` with the default `--private-key-env ALTLLM_WALLET_PRIVATE_KEY`
 - `--private-key-env <ENV_NAME>`
 - `--private-key-file <path>`
+- `--private-key <hex>` with `--allow-unsafe-private-key-argv`
 
-Direct `--private-key` usage is still available for compatibility, but now requires `--allow-unsafe-private-key-argv`.
+Direct `--private-key` usage is still available for compatibility, but requires `--allow-unsafe-private-key-argv` because command-line arguments can leak through shell history and process listings:
+
+```bash
+node dist/cli.js login-wallet \
+  --base-url https://platform-api.altllm.ai \
+  --wallet-address 0x... \
+  --private-key <hex-private-key> \
+  --allow-unsafe-private-key-argv
+```
 
 If the wallet can sign but you do not control its private key locally, prepare a challenge first:
 

--- a/skills/altllm-portal-auth/references/cli-reference.md
+++ b/skills/altllm-portal-auth/references/cli-reference.md
@@ -25,12 +25,22 @@ Representative stdout:
 }
 ```
 
-Safer key input paths:
+Local private-key input options:
 
+- `ALTLLM_WALLET_PRIVATE_KEY=<private-key>` with the default `--private-key-env ALTLLM_WALLET_PRIVATE_KEY`
 - `--private-key-env <ENV_NAME>`
 - `--private-key-file <path>`
+- `--private-key <hex>` with `--allow-unsafe-private-key-argv`
 
-Direct `--private-key` usage now requires `--allow-unsafe-private-key-argv`.
+Direct `--private-key` usage requires `--allow-unsafe-private-key-argv` because command-line arguments can leak through shell history and process listings:
+
+```bash
+node dist/cli.js login-wallet \
+  --base-url https://platform-api.altllm.ai \
+  --wallet-address 0x... \
+  --private-key <hex-private-key> \
+  --allow-unsafe-private-key-argv
+```
 
 ### Prepare challenge for external signing
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+import { createRequire } from "node:module";
+
 import { Command } from "commander";
 
 import { createApiKey } from "./commands/create-api-key.js";
@@ -32,6 +34,9 @@ import { usageSummary } from "./commands/usage-summary.js";
 import { usageTimeline } from "./commands/usage-timeline.js";
 import { CliError } from "./lib/api.js";
 import { DEFAULT_SESSION_FILE } from "./lib/session.js";
+
+const require = createRequire(import.meta.url);
+const packageJson = require("../package.json") as { version: string };
 
 const program = new Command();
 const DEFAULT_CLOUD_CLAW_BASE_URL =
@@ -79,6 +84,7 @@ function parseBooleanOption(value: string, optionName: string): boolean {
 
 program
   .name("altllm")
+  .version(packageJson.version)
   .description("CLI for AltLLM Portal auth, API key management, billing, and payments");
 
 program


### PR DESCRIPTION
## Summary
- wire Commander version output to the package.json version
- enable altllm --version / -V to report the published CLI version
- document login-wallet inline --private-key usage alongside safer env/file options

## Validation
- npm install
- npm run typecheck
- npm run build
- node dist/cli.js --version