### PR TITLE
Harden CLI validation and usability

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,6 +86,7 @@ Before shipping a change:
 
 ```bash
 npm install
+npm test
 npm run typecheck
 npm run build
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,11 @@ Current commands:
 - `altllm cloud-claw-delete`
 - `altllm cloud-claw-logs`
 
+Common aliases:
+
+- `altllm balance` -> `altllm credit`
+- `altllm keys` -> `altllm list-api-keys`
+
 Portal commands target the AltLLM Portal API. Cloud Claw commands target Cloud Claw through Portal SSO. The `altllm` CLI commands do not operate the OpenAI-compatible gateway; generated API keys are used there separately.
 
 ## Default Target

--- a/README.md
+++ b/README.md
@@ -53,6 +53,11 @@ Current commands:
 - `altllm cloud-claw-delete`
 - `altllm cloud-claw-logs`
 
+Common aliases:
+
+- `altllm balance` -> `altllm credit`
+- `altllm keys` -> `altllm list-api-keys`
+
 Portal commands target the AltLLM Portal API. Cloud Claw commands target Cloud Claw through Portal SSO. The `altllm` CLI commands do not operate the OpenAI-compatible gateway; generated API keys are used there separately.
 
 ## Default API
@@ -476,8 +481,7 @@ View usage by API key:
 ```bash
 node dist/cli.js usage-by-key \
   --base-url https://platform-api.altllm.ai \
-  --start-date 2026-03-01 \
-  --end-date 2026-03-31
+  --month 2026-03
 ```
 
 ## Payments

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ If a command is reusing your saved Portal session token, the CLI will refuse to 
 
 ```bash
 npm install
+npm test
 npm run typecheck
 npm run build
 ```

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "prepare:test-wallets": "node scripts/prepare-test-wallets.mjs",
     "e2e:model-billing": "node scripts/run-model-billing-e2e.mjs",
     "smoke:multi-user": "node scripts/run-multi-user-smoke.mjs",
+    "test": "node --import tsx --test \"test/**/*.test.ts\"",
     "typecheck": "tsc --noEmit"
   },
   "repository": {

--- a/skills/altllm-portal-api-keys/SKILL.md
+++ b/skills/altllm-portal-api-keys/SKILL.md
@@ -32,6 +32,7 @@ Portal API key lifecycle management for the local `altllm` CLI.
 - Flex users can allowlist normal AltLLM models and Flex-only `altllm-flex-*` models; backend access checks remain authoritative.
 - `update-api-key --status disabled` is reversible.
 - `revoke-api-key` is permanent.
+- `keys` is an alias for `list-api-keys`.
 
 ## Known Production Limitation
 

--- a/skills/altllm-portal-api-keys/references/cli-reference.md
+++ b/skills/altllm-portal-api-keys/references/cli-reference.md
@@ -9,6 +9,8 @@ node dist/cli.js list-api-keys \
   --base-url https://platform-api.altllm.ai
 ```
 
+Alias: `node dist/cli.js keys`
+
 ### Create key
 
 ```bash

--- a/skills/altllm-portal-billing/SKILL.md
+++ b/skills/altllm-portal-billing/SKILL.md
@@ -34,7 +34,8 @@ Balance, promo, transaction history, and usage analytics for the local `altllm` 
 - `transactions` supports `--page`, `--limit`, and `--type`.
 - `usage-summary` currently reflects the current calendar month only.
 - `usage-timeline` and `usage-by-model` support either `--month` or a complete explicit date range.
-- `usage-by-key` currently requires a complete explicit date range.
+- `usage-by-key` supports either `--month` or a complete explicit date range.
+- `balance` is an alias for `credit`.
 
 ## Reference
 

--- a/skills/altllm-portal-billing/references/cli-reference.md
+++ b/skills/altllm-portal-billing/references/cli-reference.md
@@ -9,6 +9,8 @@ node dist/cli.js credit \
   --base-url https://platform-api.altllm.ai
 ```
 
+Alias: `node dist/cli.js balance`
+
 `credit` passes through plan/model-access metadata when Portal returns it. Use it to inspect Personal tiers (`free`, `basic`, `pro`, `power`) or Business/Flex (`subscription_tier: "flex"`) status and allowed models. Flex can include normal AltLLM models plus Flex-only IDs such as `altllm-flex-gpt-5.5`, `altllm-flex-opus-4.7`, and `altllm-flex-gemini-3.1`, subject to backend access checks.
 
 ### Redeem promo
@@ -70,8 +72,7 @@ node dist/cli.js usage-by-model \
 ```bash
 node dist/cli.js usage-by-key \
   --base-url https://platform-api.altllm.ai \
-  --start-date 2026-03-01 \
-  --end-date 2026-03-31
+  --month 2026-03
 ```
 
 ## Notes
@@ -80,4 +81,4 @@ node dist/cli.js usage-by-key \
 - This repo does not implement plan billing logic or bypass Portal/Gateway model-access checks.
 - Transaction history and usage analytics are useful for validating gateway metering behavior.
 - `usage-timeline` and `usage-by-model` accept either `--month` or a complete `--start-date` / `--end-date` range, but not both.
-- `usage-by-key` requires both `--start-date` and `--end-date`.
+- `usage-by-key` accepts either `--month` or a complete `--start-date` / `--end-date` range, but not both.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -70,6 +70,24 @@ function parsePositiveNumberOption(value: string, optionName: string): number {
   return parsed;
 }
 
+function parseMinimumNumberOption(
+  value: string,
+  optionName: string,
+  minimum: number,
+  unitDescription: string
+): number {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) {
+    throw new CliError(`${optionName} must be a number.`);
+  }
+
+  if (parsed < minimum) {
+    throw new CliError(`${optionName} must be >= ${minimum} ${unitDescription}.`);
+  }
+
+  return parsed;
+}
+
 function parseBooleanOption(value: string, optionName: string): boolean {
   const normalized = value.trim().toLowerCase();
   if (normalized === "true") {
@@ -85,7 +103,24 @@ function parseBooleanOption(value: string, optionName: string): boolean {
 program
   .name("altllm")
   .version(packageJson.version)
-  .description("CLI for AltLLM Portal and Cloud Claw operations");
+  .description("CLI for AltLLM Portal and Cloud Claw operations")
+  .showHelpAfterError("(run 'altllm --help' for available commands)")
+  .showSuggestionAfterError()
+  .addHelpText(
+    "after",
+    `
+Common aliases:
+  altllm balance            alias for credit
+  altllm keys               alias for list-api-keys
+
+Examples:
+  altllm login-wallet --wallet-address 0x... --private-key-env ALTLLM_WALLET_PRIVATE_KEY
+  altllm balance
+  altllm keys
+  altllm usage-by-key --month 2026-05
+  altllm topup-crypto --amount 25 --pay-currency usdcbase
+`
+  );
 
 program
   .command("login-wallet")
@@ -348,6 +383,7 @@ program
 
 program
   .command("credit")
+  .alias("balance")
   .option("--base-url <url>", "Portal API base URL")
   .option("--session-file <path>", "Path to the saved Portal session", DEFAULT_SESSION_FILE)
   .option("--allow-token-host-mismatch", PORTAL_TOKEN_HOST_MISMATCH_OPTION, false)
@@ -434,6 +470,7 @@ program
   .option("--base-url <url>", "Portal API base URL")
   .option("--session-file <path>", "Path to the saved Portal session", DEFAULT_SESSION_FILE)
   .option("--allow-token-host-mismatch", PORTAL_TOKEN_HOST_MISMATCH_OPTION, false)
+  .option("--month <yyyy-mm>", "Month shortcut in YYYY-MM format")
   .option("--start-date <yyyy-mm-dd>", "Start date in YYYY-MM-DD format")
   .option("--end-date <yyyy-mm-dd>", "End date in YYYY-MM-DD format")
   .action(async (options) => {
@@ -441,6 +478,7 @@ program
       baseUrl: options.baseUrl,
       sessionFile: options.sessionFile,
       allowTokenHostMismatch: Boolean(options.allowTokenHostMismatch),
+      month: options.month,
       startDate: options.startDate,
       endDate: options.endDate,
     });
@@ -448,6 +486,7 @@ program
 
 program
   .command("list-api-keys")
+  .alias("keys")
   .option("--base-url <url>", "Portal API base URL")
   .option("--session-file <path>", "Path to the saved Portal session", DEFAULT_SESSION_FILE)
   .option("--allow-token-host-mismatch", PORTAL_TOKEN_HOST_MISMATCH_OPTION, false)
@@ -565,7 +604,7 @@ program
   .option("--timeout <seconds>", "Maximum wait time in seconds", "600")
   .action(async (options) => {
     await topupCrypto({
-      amount: Number(options.amount),
+      amount: parseMinimumNumberOption(options.amount, "--amount", 0.5, "USD"),
       baseUrl: options.baseUrl,
       payCurrency: options.payCurrency,
       discountCode: options.discountCode,

--- a/src/commands/topup-crypto.ts
+++ b/src/commands/topup-crypto.ts
@@ -290,7 +290,7 @@ export async function fetchPaymentLinkStatus(
 }
 
 export function isTerminalPaymentLinkStatus(status: string): boolean {
-  return TERMINAL_STATUSES.has(status);
+  return TERMINAL_STATUSES.has(status.trim().toLowerCase());
 }
 
 export function formatPaymentLinkRecord(

--- a/src/commands/transactions.ts
+++ b/src/commands/transactions.ts
@@ -16,12 +16,6 @@ export interface TransactionsOptions {
 }
 
 export async function transactions(options: TransactionsOptions): Promise<void> {
-  const { baseUrl, token } = await resolvePortalContext({
-    baseUrl: options.baseUrl,
-    sessionFile: options.sessionFile || DEFAULT_SESSION_FILE,
-    allowTokenHostMismatch: options.allowTokenHostMismatch,
-  });
-
   const searchParams = new URLSearchParams();
   appendPaginationParams(searchParams, {
     page: options.page,
@@ -31,6 +25,12 @@ export async function transactions(options: TransactionsOptions): Promise<void> 
   if (options.type !== undefined) {
     searchParams.set("type", parseTransactionFilterType(options.type));
   }
+
+  const { baseUrl, token } = await resolvePortalContext({
+    baseUrl: options.baseUrl,
+    sessionFile: options.sessionFile || DEFAULT_SESSION_FILE,
+    allowTokenHostMismatch: options.allowTokenHostMismatch,
+  });
 
   const suffix = searchParams.size > 0 ? `?${searchParams.toString()}` : "";
   const result = await requestJson<Record<string, unknown>>({

--- a/src/commands/usage-by-key.ts
+++ b/src/commands/usage-by-key.ts
@@ -12,16 +12,16 @@ export interface UsageByKeyOptions {
 }
 
 export async function usageByKey(options: UsageByKeyOptions): Promise<void> {
-  const { baseUrl, token } = await resolvePortalContext({
-    baseUrl: options.baseUrl,
-    sessionFile: options.sessionFile || DEFAULT_SESSION_FILE,
-    allowTokenHostMismatch: options.allowTokenHostMismatch,
-  });
-
   const searchParams = new URLSearchParams();
   appendRequiredDateRangeParams(searchParams, {
     startDate: options.startDate,
     endDate: options.endDate,
+  });
+
+  const { baseUrl, token } = await resolvePortalContext({
+    baseUrl: options.baseUrl,
+    sessionFile: options.sessionFile || DEFAULT_SESSION_FILE,
+    allowTokenHostMismatch: options.allowTokenHostMismatch,
   });
 
   const suffix = searchParams.size > 0 ? `?${searchParams.toString()}` : "";

--- a/src/commands/usage-by-key.ts
+++ b/src/commands/usage-by-key.ts
@@ -1,5 +1,5 @@
 import { requestJson } from "../lib/api.js";
-import { appendRequiredDateRangeParams } from "../lib/history.js";
+import { appendRequiredDateRangeOrMonthParams } from "../lib/history.js";
 import { resolvePortalContext, writeJson } from "../lib/keys.js";
 import { DEFAULT_SESSION_FILE } from "../lib/session.js";
 
@@ -8,14 +8,16 @@ export interface UsageByKeyOptions {
   sessionFile: string;
   startDate?: string;
   endDate?: string;
+  month?: string;
   allowTokenHostMismatch?: boolean;
 }
 
 export async function usageByKey(options: UsageByKeyOptions): Promise<void> {
   const searchParams = new URLSearchParams();
-  appendRequiredDateRangeParams(searchParams, {
+  appendRequiredDateRangeOrMonthParams(searchParams, {
     startDate: options.startDate,
     endDate: options.endDate,
+    month: options.month,
   });
 
   const { baseUrl, token } = await resolvePortalContext({

--- a/src/commands/usage-by-model.ts
+++ b/src/commands/usage-by-model.ts
@@ -13,17 +13,17 @@ export interface UsageByModelOptions {
 }
 
 export async function usageByModel(options: UsageByModelOptions): Promise<void> {
-  const { baseUrl, token } = await resolvePortalContext({
-    baseUrl: options.baseUrl,
-    sessionFile: options.sessionFile || DEFAULT_SESSION_FILE,
-    allowTokenHostMismatch: options.allowTokenHostMismatch,
-  });
-
   const searchParams = new URLSearchParams();
   appendMonthOrDateRangeParams(searchParams, {
     startDate: options.startDate,
     endDate: options.endDate,
     month: options.month,
+  });
+
+  const { baseUrl, token } = await resolvePortalContext({
+    baseUrl: options.baseUrl,
+    sessionFile: options.sessionFile || DEFAULT_SESSION_FILE,
+    allowTokenHostMismatch: options.allowTokenHostMismatch,
   });
 
   const suffix = searchParams.size > 0 ? `?${searchParams.toString()}` : "";

--- a/src/commands/usage-timeline.ts
+++ b/src/commands/usage-timeline.ts
@@ -13,17 +13,17 @@ export interface UsageTimelineOptions {
 }
 
 export async function usageTimeline(options: UsageTimelineOptions): Promise<void> {
-  const { baseUrl, token } = await resolvePortalContext({
-    baseUrl: options.baseUrl,
-    sessionFile: options.sessionFile || DEFAULT_SESSION_FILE,
-    allowTokenHostMismatch: options.allowTokenHostMismatch,
-  });
-
   const searchParams = new URLSearchParams();
   appendMonthOrDateRangeParams(searchParams, {
     startDate: options.startDate,
     endDate: options.endDate,
     month: options.month,
+  });
+
+  const { baseUrl, token } = await resolvePortalContext({
+    baseUrl: options.baseUrl,
+    sessionFile: options.sessionFile || DEFAULT_SESSION_FILE,
+    allowTokenHostMismatch: options.allowTokenHostMismatch,
   });
 
   const suffix = searchParams.size > 0 ? `?${searchParams.toString()}` : "";

--- a/src/lib/history.ts
+++ b/src/lib/history.ts
@@ -18,6 +18,19 @@ function normalizeMonth(value: string): string {
   return month;
 }
 
+function monthToDateRange(value: string): { startDate: string; endDate: string } {
+  const month = normalizeMonth(value);
+  const [yearText, monthText] = month.split("-");
+  const year = Number(yearText);
+  const monthNumber = Number(monthText);
+  const lastDay = new Date(Date.UTC(year, monthNumber, 0)).getUTCDate();
+
+  return {
+    startDate: `${month}-01`,
+    endDate: `${month}-${String(lastDay).padStart(2, "0")}`,
+  };
+}
+
 function normalizeDate(value: string, label: string): string {
   const date = value.trim();
   const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(date);
@@ -122,6 +135,36 @@ export function appendRequiredDateRangeParams(
 
   if (hasStartDate !== hasEndDate) {
     throw new CliError("Provide both --start-date and --end-date.");
+  }
+
+  appendDateRangeParams(searchParams, params);
+}
+
+export function appendRequiredDateRangeOrMonthParams(
+  searchParams: URLSearchParams,
+  params: { startDate?: string; endDate?: string; month?: string }
+): void {
+  const hasMonth = params.month !== undefined;
+  const hasStartDate = params.startDate !== undefined;
+  const hasEndDate = params.endDate !== undefined;
+
+  if (hasMonth && (hasStartDate || hasEndDate)) {
+    throw new CliError("Use either --month or --start-date/--end-date, but not both.");
+  }
+
+  if (params.month !== undefined) {
+    const { startDate, endDate } = monthToDateRange(params.month);
+    searchParams.set("start_date", startDate);
+    searchParams.set("end_date", endDate);
+    return;
+  }
+
+  if (!hasStartDate && !hasEndDate) {
+    throw new CliError("Provide --month or both --start-date and --end-date.");
+  }
+
+  if (hasStartDate !== hasEndDate) {
+    throw new CliError("Provide both --start-date and --end-date, or use --month.");
   }
 
   appendDateRangeParams(searchParams, params);

--- a/src/lib/history.ts
+++ b/src/lib/history.ts
@@ -3,6 +3,44 @@ import { CliError } from "./api.js";
 export const TRANSACTION_FILTER_TYPES = ["all", "credit", "usage", "refund"] as const;
 export type TransactionFilterType = (typeof TRANSACTION_FILTER_TYPES)[number];
 
+function normalizeMonth(value: string): string {
+  const month = value.trim();
+  const match = /^(\d{4})-(\d{2})$/.exec(month);
+  if (!match) {
+    throw new CliError("Month must be in YYYY-MM format.");
+  }
+
+  const monthNumber = Number(match[2]);
+  if (monthNumber < 1 || monthNumber > 12) {
+    throw new CliError("Month must be a valid calendar month in YYYY-MM format.");
+  }
+
+  return month;
+}
+
+function normalizeDate(value: string, label: string): string {
+  const date = value.trim();
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(date);
+  if (!match) {
+    throw new CliError(`${label} must be in YYYY-MM-DD format.`);
+  }
+
+  const year = Number(match[1]);
+  const monthIndex = Number(match[2]) - 1;
+  const day = Number(match[3]);
+  const parsed = new Date(Date.UTC(year, monthIndex, day));
+
+  if (
+    parsed.getUTCFullYear() !== year ||
+    parsed.getUTCMonth() !== monthIndex ||
+    parsed.getUTCDate() !== day
+  ) {
+    throw new CliError(`${label} must be a valid calendar date in YYYY-MM-DD format.`);
+  }
+
+  return date;
+}
+
 export function appendPaginationParams(
   searchParams: URLSearchParams,
   params: { page?: number; limit?: number }
@@ -27,27 +65,28 @@ export function appendDateRangeParams(
   params: { startDate?: string; endDate?: string; month?: string }
 ): void {
   if (params.month !== undefined) {
-    const month = params.month.trim();
-    if (!/^\d{4}-\d{2}$/.test(month)) {
-      throw new CliError("Month must be in YYYY-MM format.");
-    }
-    searchParams.set("month", month);
+    searchParams.set("month", normalizeMonth(params.month));
   }
 
+  let normalizedStartDate: string | undefined;
+  let normalizedEndDate: string | undefined;
+
   if (params.startDate !== undefined) {
-    const startDate = params.startDate.trim();
-    if (!/^\d{4}-\d{2}-\d{2}$/.test(startDate)) {
-      throw new CliError("Start date must be in YYYY-MM-DD format.");
-    }
-    searchParams.set("start_date", startDate);
+    normalizedStartDate = normalizeDate(params.startDate, "Start date");
+    searchParams.set("start_date", normalizedStartDate);
   }
 
   if (params.endDate !== undefined) {
-    const endDate = params.endDate.trim();
-    if (!/^\d{4}-\d{2}-\d{2}$/.test(endDate)) {
-      throw new CliError("End date must be in YYYY-MM-DD format.");
-    }
-    searchParams.set("end_date", endDate);
+    normalizedEndDate = normalizeDate(params.endDate, "End date");
+    searchParams.set("end_date", normalizedEndDate);
+  }
+
+  if (
+    normalizedStartDate !== undefined &&
+    normalizedEndDate !== undefined &&
+    normalizedStartDate > normalizedEndDate
+  ) {
+    throw new CliError("Start date must be on or before end date.");
   }
 }
 

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -1,0 +1,76 @@
+import assert from "node:assert/strict";
+import { execFile } from "node:child_process";
+import test from "node:test";
+
+interface CliResult {
+  code: number | null;
+  stdout: string;
+  stderr: string;
+}
+
+function runCli(args: string[]): Promise<CliResult> {
+  return new Promise((resolve, reject) => {
+    execFile(
+      process.execPath,
+      ["--import", "tsx", "src/cli.ts", ...args],
+      { cwd: process.cwd() },
+      (error, stdout, stderr) => {
+        if (error && !("code" in error)) {
+          reject(error);
+          return;
+        }
+
+        resolve({
+          code:
+            error && "code" in error && typeof error.code === "number"
+              ? error.code
+              : 0,
+          stdout,
+          stderr,
+        });
+      }
+    );
+  });
+}
+
+test("root help highlights aliases and common examples", async () => {
+  const result = await runCli(["--help"]);
+
+  assert.equal(result.code, 0);
+  assert.match(result.stdout, /Common aliases:/);
+  assert.match(result.stdout, /altllm balance\s+alias for credit/);
+  assert.match(result.stdout, /altllm usage-by-key --month 2026-05/);
+});
+
+test("mistyped commands include a suggestion and help hint", async () => {
+  const result = await runCli(["balnce"]);
+
+  assert.equal(result.code, 1);
+  assert.match(result.stderr, /unknown command 'balnce'/);
+  assert.match(result.stderr, /Did you mean (balance|credit)\?/);
+  assert.match(result.stderr, /altllm --help/);
+});
+
+test("aliases expose command help", async () => {
+  const balance = await runCli(["balance", "--help"]);
+  const keys = await runCli(["keys", "--help"]);
+
+  assert.equal(balance.code, 0);
+  assert.match(balance.stdout, /Usage: altllm credit\|balance/);
+  assert.equal(keys.code, 0);
+  assert.match(keys.stdout, /Usage: altllm list-api-keys\|keys/);
+});
+
+test("topup amount parsing fails before session loading", async () => {
+  const result = await runCli([
+    "topup-crypto",
+    "--amount",
+    "abc",
+    "--session-file",
+    "/tmp/altllm-missing-session.json",
+  ]);
+
+  assert.equal(result.code, 1);
+  assert.match(result.stderr, /--amount must be a number/);
+  assert.doesNotMatch(result.stderr, /Session file not found/);
+});

--- a/test/history.test.ts
+++ b/test/history.test.ts
@@ -1,0 +1,110 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { CliError } from "../src/lib/api.js";
+import {
+  appendDateRangeParams,
+  appendMonthOrDateRangeParams,
+  appendPaginationParams,
+  appendRequiredDateRangeParams,
+  parseTransactionFilterType,
+} from "../src/lib/history.js";
+
+function assertCliError(fn: () => void, message: string): void {
+  assert.throws(
+    fn,
+    (error) => error instanceof CliError && error.message === message
+  );
+}
+
+test("appendPaginationParams validates and appends page and limit", () => {
+  const searchParams = new URLSearchParams();
+
+  appendPaginationParams(searchParams, { page: 2, limit: 50 });
+
+  assert.equal(searchParams.get("page"), "2");
+  assert.equal(searchParams.get("limit"), "50");
+  assertCliError(
+    () => appendPaginationParams(new URLSearchParams(), { page: 0 }),
+    "Page must be an integer >= 1."
+  );
+  assertCliError(
+    () => appendPaginationParams(new URLSearchParams(), { limit: 101 }),
+    "Limit must be an integer between 1 and 100."
+  );
+});
+
+test("appendDateRangeParams validates real calendar dates and month values", () => {
+  const searchParams = new URLSearchParams();
+
+  appendDateRangeParams(searchParams, {
+    month: " 2024-02 ",
+    startDate: "2024-02-01",
+    endDate: "2024-02-29",
+  });
+
+  assert.equal(searchParams.get("month"), "2024-02");
+  assert.equal(searchParams.get("start_date"), "2024-02-01");
+  assert.equal(searchParams.get("end_date"), "2024-02-29");
+  assertCliError(
+    () => appendDateRangeParams(new URLSearchParams(), { month: "2024-13" }),
+    "Month must be a valid calendar month in YYYY-MM format."
+  );
+  assertCliError(
+    () => appendDateRangeParams(new URLSearchParams(), { startDate: "2026-02-29" }),
+    "Start date must be a valid calendar date in YYYY-MM-DD format."
+  );
+  assertCliError(
+    () => appendDateRangeParams(new URLSearchParams(), { endDate: "2026-04-31" }),
+    "End date must be a valid calendar date in YYYY-MM-DD format."
+  );
+  assertCliError(
+    () =>
+      appendDateRangeParams(new URLSearchParams(), {
+        startDate: "2024-03-01",
+        endDate: "2024-02-29",
+      }),
+    "Start date must be on or before end date."
+  );
+});
+
+test("appendMonthOrDateRangeParams rejects ambiguous or partial ranges", () => {
+  assertCliError(
+    () =>
+      appendMonthOrDateRangeParams(new URLSearchParams(), {
+        month: "2024-02",
+        startDate: "2024-02-01",
+        endDate: "2024-02-29",
+      }),
+    "Use either --month or --start-date/--end-date, but not both."
+  );
+  assertCliError(
+    () =>
+      appendMonthOrDateRangeParams(new URLSearchParams(), {
+        startDate: "2024-02-01",
+      }),
+    "Provide both --start-date and --end-date for an explicit date range."
+  );
+});
+
+test("appendRequiredDateRangeParams requires both dates", () => {
+  assertCliError(
+    () => appendRequiredDateRangeParams(new URLSearchParams(), {}),
+    "Provide both --start-date and --end-date."
+  );
+  assertCliError(
+    () =>
+      appendRequiredDateRangeParams(new URLSearchParams(), {
+        endDate: "2024-02-29",
+      }),
+    "Provide both --start-date and --end-date."
+  );
+});
+
+test("parseTransactionFilterType normalizes supported filters", () => {
+  assert.equal(parseTransactionFilterType(" CREDIT "), "credit");
+  assertCliError(
+    () => parseTransactionFilterType("debit"),
+    "Invalid transaction type: debit. Expected one of all, credit, usage, refund."
+  );
+});

--- a/test/history.test.ts
+++ b/test/history.test.ts
@@ -6,6 +6,7 @@ import {
   appendDateRangeParams,
   appendMonthOrDateRangeParams,
   appendPaginationParams,
+  appendRequiredDateRangeOrMonthParams,
   appendRequiredDateRangeParams,
   parseTransactionFilterType,
 } from "../src/lib/history.js";
@@ -98,6 +99,38 @@ test("appendRequiredDateRangeParams requires both dates", () => {
         endDate: "2024-02-29",
       }),
     "Provide both --start-date and --end-date."
+  );
+});
+
+test("appendRequiredDateRangeOrMonthParams expands month shortcuts", () => {
+  const searchParams = new URLSearchParams();
+
+  appendRequiredDateRangeOrMonthParams(searchParams, { month: "2024-02" });
+
+  assert.equal(searchParams.get("start_date"), "2024-02-01");
+  assert.equal(searchParams.get("end_date"), "2024-02-29");
+});
+
+test("appendRequiredDateRangeOrMonthParams rejects missing or ambiguous ranges", () => {
+  assertCliError(
+    () => appendRequiredDateRangeOrMonthParams(new URLSearchParams(), {}),
+    "Provide --month or both --start-date and --end-date."
+  );
+  assertCliError(
+    () =>
+      appendRequiredDateRangeOrMonthParams(new URLSearchParams(), {
+        month: "2024-02",
+        startDate: "2024-02-01",
+        endDate: "2024-02-29",
+      }),
+    "Use either --month or --start-date/--end-date, but not both."
+  );
+  assertCliError(
+    () =>
+      appendRequiredDateRangeOrMonthParams(new URLSearchParams(), {
+        startDate: "2024-02-01",
+      }),
+    "Provide both --start-date and --end-date, or use --month."
   );
 });
 

--- a/test/keys.test.ts
+++ b/test/keys.test.ts
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { CliError } from "../src/lib/api.js";
+import {
+  buildKeyPermissions,
+  parseMutableKeyStatus,
+  validateApiKeyName,
+} from "../src/lib/keys.js";
+
+function assertCliError(fn: () => void, message: string): void {
+  assert.throws(
+    fn,
+    (error) => error instanceof CliError && error.message === message
+  );
+}
+
+test("buildKeyPermissions trims, dedupes, and combines model inputs", () => {
+  assert.deepEqual(
+    buildKeyPermissions({
+      model: [" altllm-fast ", "altllm-standard"],
+      models: "altllm-fast, altllm-basic",
+    }),
+    { models: ["altllm-fast", "altllm-standard", "altllm-basic"] }
+  );
+  assert.equal(buildKeyPermissions({}), undefined);
+});
+
+test("buildKeyPermissions rejects empty or invalid model lists", () => {
+  assertCliError(
+    () => buildKeyPermissions({ models: " , " }),
+    "Provide at least one non-empty model ID."
+  );
+  assertCliError(
+    () => buildKeyPermissions({ model: ["gpt-4"] }),
+    "Invalid model ID: gpt-4. Model IDs must start with 'altllm-'."
+  );
+});
+
+test("validateApiKeyName normalizes valid names and rejects unsafe names", () => {
+  assert.equal(validateApiKeyName("  staging smoke-key.1  "), "staging smoke-key.1");
+  assertCliError(() => validateApiKeyName("  "), "API key name cannot be empty.");
+  assertCliError(
+    () => validateApiKeyName("name/with/slash"),
+    "API key name can only contain letters, numbers, spaces, hyphens, underscores, and periods."
+  );
+  assertCliError(
+    () => validateApiKeyName("a".repeat(65)),
+    "API key name must be 64 characters or fewer."
+  );
+});
+
+test("parseMutableKeyStatus normalizes supported statuses", () => {
+  assert.equal(parseMutableKeyStatus(" DISABLED "), "disabled");
+  assertCliError(
+    () => parseMutableKeyStatus("expired"),
+    "Invalid API key status: expired. Expected one of active, disabled, revoked."
+  );
+});

--- a/test/payments.test.ts
+++ b/test/payments.test.ts
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { CliError } from "../src/lib/api.js";
+import {
+  formatPaymentDiscountFields,
+  isTerminalPaymentLinkStatus,
+  normalizeAllowedPayCurrencies,
+  validateDiscountPayCurrency,
+} from "../src/commands/topup-crypto.js";
+
+function assertCliError(fn: () => void, message: string): void {
+  assert.throws(
+    fn,
+    (error) => error instanceof CliError && error.message === message
+  );
+}
+
+test("normalizeAllowedPayCurrencies trims, lowercases, and dedupes", () => {
+  assert.deepEqual(
+    normalizeAllowedPayCurrencies({
+      allowed_pay_currencies: [" USDCBASE ", "usdcbase", "", "eth"],
+    }),
+    ["usdcbase", "eth"]
+  );
+});
+
+test("validateDiscountPayCurrency rejects token-scoped mismatches", () => {
+  validateDiscountPayCurrency({
+    discountCode: "BASEONLY",
+    payCurrency: "USDCBASE",
+    allowedPayCurrencies: ["usdcbase"],
+  });
+  assertCliError(
+    () =>
+      validateDiscountPayCurrency({
+        discountCode: "BASEONLY",
+        payCurrency: "sol",
+        allowedPayCurrencies: ["usdcbase", "eth"],
+      }),
+    "Discount code BASEONLY can only be used with: usdcbase, eth."
+  );
+});
+
+test("formatPaymentDiscountFields prefers primary response values", () => {
+  assert.deepEqual(
+    formatPaymentDiscountFields(
+      {
+        promo_code: null,
+        discount_amount: "4",
+        final_amount: "21",
+      },
+      {
+        promo_code: "SAVE",
+        original_amount: "25",
+        discount_percent: "16",
+        discount_amount: "3",
+        final_amount: "22",
+        allowed_pay_currencies: ["usdcbase"],
+      }
+    ),
+    {
+      discountCode: "SAVE",
+      originalAmount: "25",
+      discountPercent: "16",
+      discountAmount: "4",
+      finalAmount: "21",
+      allowedPayCurrencies: ["usdcbase"],
+    }
+  );
+});
+
+test("isTerminalPaymentLinkStatus handles provider casing and whitespace", () => {
+  assert.equal(isTerminalPaymentLinkStatus(" completed "), true);
+  assert.equal(isTerminalPaymentLinkStatus("FAILED"), true);
+  assert.equal(isTerminalPaymentLinkStatus("pending"), false);
+});


### PR DESCRIPTION
## Summary
- validate real calendar dates/ranges before loading Portal sessions
- add node:test coverage for history, key, payment, and CLI help/error guardrails
- normalize terminal payment-link status checks for provider casing/whitespace
- add root help examples, typo suggestions, and aliases for common commands
- let usage-by-key accept --month as a shortcut for the full calendar-month date range
- document the new npm test verification step

## Tests
- npm test
- npm run typecheck
- npm run build