### PR TITLE
Add B402 x402 CLI commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,9 @@ Current commands:
 - `altllm topup-crypto`
 - `altllm payment-status`
 - `altllm pay-payment-link`
+- `altllm b402-supported`
+- `altllm b402-verify`
+- `altllm b402-settle`
 - `altllm cloud-claw-me`
 - `altllm cloud-claw-deployments`
 - `altllm cloud-claw-deployment`

--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ Current commands:
 - `altllm topup-crypto`
 - `altllm payment-status`
 - `altllm pay-payment-link`
+- `altllm b402-supported`
+- `altllm b402-verify`
+- `altllm b402-settle`
 - `altllm cloud-claw-me`
 - `altllm cloud-claw-deployments`
 - `altllm cloud-claw-deployment`
@@ -154,6 +157,28 @@ Use this when the user wants current balance, billing transactions, or usage his
 `altllm-portal-payments` -> `altllm-portal-billing`
 
 Use this when the user needs to create a payment link, wait for settlement, and then confirm the resulting balance or usage changes.
+
+**Binance B402 / x402 Merchant Flow**
+
+Use this when testing Binance B402 facilitator endpoints for x402:
+
+```bash
+export B402_BASE_URL=<b402-base-url>
+export B402_CLIENT_ID=<client-id>
+export B402_ACCESS_TOKEN=<access-token>
+export B402_PRIVATE_KEY_FILE=/path/to/private_key.base64
+
+node dist/cli.js b402-supported \
+  --private-key-file "$B402_PRIVATE_KEY_FILE"
+```
+
+`b402-supported` sends `{}` by default. `b402-verify` and `b402-settle`
+require `--body-file` with the buyer-signed x402 JSON payload:
+
+```bash
+node dist/cli.js b402-verify --body-file payment.json
+node dist/cli.js b402-settle --body-file payment.json
+```
 
 **Launch and Manage AltClaw**
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -3,6 +3,7 @@ import { createRequire } from "node:module";
 
 import { Command } from "commander";
 
+import { b402Command, type B402Endpoint } from "./commands/b402.js";
 import { createApiKey } from "./commands/create-api-key.js";
 import { cloudClawDeployment } from "./commands/cloud-claw-deployment.js";
 import { cloudClawDeploy } from "./commands/cloud-claw-deploy.js";
@@ -119,8 +120,57 @@ Examples:
   altllm keys
   altllm usage-by-key --month 2026-05
   altllm topup-crypto --amount 25 --pay-currency usdcbase
+  altllm b402-supported --base-url https://... --client-id ...
 `
   );
+
+function addB402Command(endpoint: B402Endpoint, description: string): void {
+  program
+    .command(`b402-${endpoint}`)
+    .description(description)
+    .option("--base-url <url>", "B402 API base URL")
+    .option("--client-id <id>", "B402 merchant client id")
+    .option(
+      "--client-id-env <name>",
+      "Environment variable containing the B402 client id",
+      "B402_CLIENT_ID"
+    )
+    .option(
+      "--access-token-env <name>",
+      "Environment variable containing the B402 access token",
+      "B402_ACCESS_TOKEN"
+    )
+    .option("--access-token-file <path>", "File containing the B402 access token")
+    .option(
+      "--private-key-env <name>",
+      "Environment variable containing the Base64 PKCS#8 merchant private key",
+      "B402_PRIVATE_KEY_B64"
+    )
+    .option(
+      "--private-key-file <path>",
+      "File containing the Base64 PKCS#8 or PEM merchant private key"
+    )
+    .option(
+      "--body-file <path>",
+      "JSON body file; required for b402-verify and b402-settle"
+    )
+    .action(async (options) => {
+      await b402Command(endpoint, {
+        baseUrl: options.baseUrl,
+        clientId: options.clientId,
+        clientIdEnv: options.clientIdEnv,
+        accessTokenEnv: options.accessTokenEnv,
+        accessTokenFile: options.accessTokenFile,
+        privateKeyEnv: options.privateKeyEnv,
+        privateKeyFile: options.privateKeyFile,
+        bodyFile: options.bodyFile,
+      });
+    });
+}
+
+addB402Command("supported", "Fetch Binance B402 x402 supported configurations");
+addB402Command("verify", "Verify a buyer-signed x402 payment payload with B402");
+addB402Command("settle", "Settle a verified x402 payment payload with B402");
 
 program
   .command("login-wallet")

--- a/src/commands/b402.ts
+++ b/src/commands/b402.ts
@@ -1,0 +1,217 @@
+import { createPrivateKey, createSign } from "node:crypto";
+import { readFile } from "node:fs/promises";
+
+import {
+  CliError,
+  fetchWithTimeout,
+  requireSecureNonLocalBaseUrl,
+} from "../lib/api.js";
+
+export type B402Endpoint = "supported" | "verify" | "settle";
+
+export interface B402Options {
+  baseUrl?: string;
+  clientId?: string;
+  clientIdEnv?: string;
+  accessTokenEnv?: string;
+  accessTokenFile?: string;
+  privateKeyEnv?: string;
+  privateKeyFile?: string;
+  bodyFile?: string;
+}
+
+const ENDPOINT_PATHS: Record<B402Endpoint, string> = {
+  supported: "/papi/v2/b402/supported",
+  verify: "/papi/v2/b402/verify",
+  settle: "/papi/v2/b402/settle",
+};
+
+async function resolveSecret(params: {
+  label: string;
+  envName?: string;
+  filePath?: string;
+}): Promise<string> {
+  if (params.filePath !== undefined) {
+    return readSecretFile(params.label, params.filePath);
+  }
+
+  const envName = params.envName?.trim();
+  if (!envName) {
+    throw new CliError(
+      `${params.label} environment variable name cannot be empty.`
+    );
+  }
+
+  const value = process.env[envName]?.trim();
+  if (!value) {
+    throw new CliError(
+      `${params.label} missing. Set ${envName} or provide --${params.label}-file.`
+    );
+  }
+  return value;
+}
+
+async function readSecretFile(label: string, filePath: string): Promise<string> {
+  const trimmedPath = filePath.trim();
+  if (!trimmedPath) {
+    throw new CliError(`--${label}-file cannot be empty.`);
+  }
+
+  const value = (await readFile(trimmedPath, "utf8")).trim();
+  if (!value) {
+    throw new CliError(`${label} file is empty: ${trimmedPath}`);
+  }
+  return value;
+}
+
+function resolveClientId(options: B402Options): string {
+  if (options.clientId?.trim()) {
+    return options.clientId.trim();
+  }
+
+  const envName = options.clientIdEnv?.trim() || "B402_CLIENT_ID";
+  const value = process.env[envName]?.trim();
+  if (!value) {
+    throw new CliError(`client-id missing. Pass --client-id or set ${envName}.`);
+  }
+  return value;
+}
+
+function resolveBaseUrl(baseUrl?: string): string {
+  const value = baseUrl?.trim() || process.env.B402_BASE_URL?.trim();
+  if (!value) {
+    throw new CliError(
+      "B402 base URL missing. Pass --base-url or set B402_BASE_URL."
+    );
+  }
+  return requireSecureNonLocalBaseUrl(value, "B402 merchant credentials");
+}
+
+async function requestBody(
+  endpoint: B402Endpoint,
+  bodyFile?: string
+): Promise<string> {
+  if (!bodyFile) {
+    if (endpoint === "supported") {
+      return "{}";
+    }
+    throw new CliError(`--body-file is required for b402-${endpoint}.`);
+  }
+
+  const body = (await readFile(bodyFile, "utf8")).trim();
+  if (!body) {
+    throw new CliError(`Body file is empty: ${bodyFile}`);
+  }
+  validateJsonBody(body, bodyFile);
+  return body;
+}
+
+function validateJsonBody(body: string, bodyFile: string): void {
+  try {
+    JSON.parse(body);
+  } catch {
+    throw new CliError(`Body file must contain valid JSON: ${bodyFile}`);
+  }
+}
+
+export function signB402Payload(params: {
+  body: string;
+  timestamp: string;
+  privateKey: string;
+}): string {
+  const signer = createSign("RSA-SHA256");
+  signer.update(params.body + params.timestamp, "utf8");
+  signer.end();
+  return signer.sign(parseMerchantPrivateKey(params.privateKey), "base64");
+}
+
+function parseMerchantPrivateKey(
+  privateKey: string
+): ReturnType<typeof createPrivateKey> {
+  const trimmed = privateKey.trim();
+  if (trimmed.includes("BEGIN")) {
+    return createPrivateKey(trimmed);
+  }
+
+  return createPrivateKey({
+    key: Buffer.from(trimmed, "base64"),
+    format: "der",
+    type: "pkcs8",
+  });
+}
+
+function b402Headers(params: {
+  clientId: string;
+  accessToken: string;
+  body: string;
+  privateKey: string;
+}): Record<string, string> {
+  const timestamp = String(Date.now());
+  return {
+    Accept: "application/json",
+    "Content-Type": "application/json",
+    "X-Tesla-ClientId": params.clientId,
+    "X-Tesla-SignAccessToken": params.accessToken,
+    "X-Tesla-Timestamp": timestamp,
+    "X-Tesla-Signature": signB402Payload({
+      body: params.body,
+      timestamp,
+      privateKey: params.privateKey,
+    }),
+  };
+}
+
+export async function requestB402(
+  endpoint: B402Endpoint,
+  options: B402Options
+): Promise<unknown> {
+  const baseUrl = resolveBaseUrl(options.baseUrl);
+  const clientId = resolveClientId(options);
+  const body = await requestBody(endpoint, options.bodyFile);
+  const accessToken = await resolveSecret({
+    label: "access-token",
+    envName: options.accessTokenEnv || "B402_ACCESS_TOKEN",
+    filePath: options.accessTokenFile,
+  });
+  const privateKey = await resolveSecret({
+    label: "private-key",
+    envName: options.privateKeyEnv || "B402_PRIVATE_KEY_B64",
+    filePath: options.privateKeyFile,
+  });
+
+  const response = await fetchWithTimeout({
+    method: "POST",
+    url: `${baseUrl}${ENDPOINT_PATHS[endpoint]}`,
+    headers: b402Headers({ clientId, accessToken, body, privateKey }),
+    body,
+  });
+
+  return parseB402Response(endpoint, response);
+}
+
+async function parseB402Response(
+  endpoint: B402Endpoint,
+  response: Response
+): Promise<unknown> {
+  const text = await response.text();
+  if (!response.ok) {
+    throw new CliError(`b402-${endpoint} failed: ${response.status} ${text}`);
+  }
+  if (!text) {
+    return {};
+  }
+
+  try {
+    return JSON.parse(text) as unknown;
+  } catch {
+    throw new CliError(`b402-${endpoint} returned invalid JSON: ${text}`);
+  }
+}
+
+export async function b402Command(
+  endpoint: B402Endpoint,
+  options: B402Options
+): Promise<void> {
+  const result = await requestB402(endpoint, options);
+  process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+}

--- a/test/b402.test.ts
+++ b/test/b402.test.ts
@@ -1,0 +1,95 @@
+import assert from "node:assert/strict";
+import { createVerify, generateKeyPairSync } from "node:crypto";
+import test from "node:test";
+
+import { CliError } from "../src/lib/api.js";
+import { requestB402, signB402Payload } from "../src/commands/b402.js";
+
+function testPrivateKeyB64(): {
+  privateKeyB64: string;
+  publicKey: ReturnType<typeof generateKeyPairSync>["publicKey"];
+} {
+  const pair = generateKeyPairSync("rsa", { modulusLength: 2048 });
+  const der = pair.privateKey.export({ format: "der", type: "pkcs8" });
+  return {
+    privateKeyB64: Buffer.from(der).toString("base64"),
+    publicKey: pair.publicKey,
+  };
+}
+
+test("signB402Payload signs body plus millisecond timestamp", () => {
+  const { privateKeyB64, publicKey } = testPrivateKeyB64();
+  const body = "{}";
+  const timestamp = "1760000000000";
+  const signature = signB402Payload({
+    body,
+    timestamp,
+    privateKey: privateKeyB64,
+  });
+  const verifier = createVerify("RSA-SHA256");
+  verifier.update(body + timestamp, "utf8");
+  verifier.end();
+
+  assert.equal(
+    verifier.verify(publicKey, Buffer.from(signature, "base64")),
+    true
+  );
+});
+
+test("requestB402 sends signed Tesla headers", async () => {
+  const { privateKeyB64 } = testPrivateKeyB64();
+  const previousFetch = globalThis.fetch;
+  const previousToken = process.env.B402_ACCESS_TOKEN;
+  const previousKey = process.env.B402_PRIVATE_KEY_B64;
+  let captured: { url?: string; init?: RequestInit } = {};
+  process.env.B402_ACCESS_TOKEN = "access-token";
+  process.env.B402_PRIVATE_KEY_B64 = privateKeyB64;
+  globalThis.fetch = async (input, init) => {
+    captured = { url: String(input), init };
+    return new Response(JSON.stringify({ ok: true }), { status: 200 });
+  };
+
+  try {
+    const result = await requestB402("supported", {
+      baseUrl: "https://b402.example",
+      clientId: "client-id",
+    });
+
+    assert.deepEqual(result, { ok: true });
+    assert.equal(
+      captured.url,
+      "https://b402.example/papi/v2/b402/supported"
+    );
+    const headers = captured.init?.headers as Record<string, string>;
+    assert.equal(headers["X-Tesla-ClientId"], "client-id");
+    assert.equal(headers["X-Tesla-SignAccessToken"], "access-token");
+    assert.match(headers["X-Tesla-Timestamp"], /^\d{13}$/);
+    assert.ok(headers["X-Tesla-Signature"]);
+    assert.equal(captured.init?.body, "{}");
+  } finally {
+    globalThis.fetch = previousFetch;
+    restoreEnv("B402_ACCESS_TOKEN", previousToken);
+    restoreEnv("B402_PRIVATE_KEY_B64", previousKey);
+  }
+});
+
+test("requestB402 requires body files for verify and settle", async () => {
+  await assert.rejects(
+    () =>
+      requestB402("verify", {
+        baseUrl: "https://b402.example",
+        clientId: "client-id",
+      }),
+    (error) =>
+      error instanceof CliError &&
+      error.message === "--body-file is required for b402-verify."
+  );
+});
+
+function restoreEnv(name: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[name];
+    return;
+  }
+  process.env[name] = value;
+}

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -61,6 +61,15 @@ test("aliases expose command help", async () => {
   assert.match(keys.stdout, /Usage: altllm list-api-keys\|keys/);
 });
 
+test("b402 command help exposes x402 body-file workflow", async () => {
+  const result = await runCli(["b402-verify", "--help"]);
+
+  assert.equal(result.code, 0);
+  assert.match(result.stdout, /Usage: altllm b402-verify/);
+  assert.match(result.stdout, /--body-file <path>/);
+  assert.match(result.stdout, /B402 access token/);
+});
+
 test("topup amount parsing fails before session loading", async () => {
   const result = await runCli([
     "topup-crypto",


### PR DESCRIPTION
## Summary
- Add signed Binance B402 commands for supported, verify, and settle endpoints.
- Load merchant access token and Base64 PKCS#8/PEM private key from env or files, with HTTPS guardrails for non-local targets.
- Document the merchant x402 workflow and add tests for RSA signing, Tesla headers, and command help.

## Validation
- npm run typecheck
- npm test
- npm run build
- Live smoke against the partner-provided QA host with a throwaway RSA key reached the host and failed at CloudFront 403 before the B402 app, matching local diagnostics.