### PR TITLE
Improve Portal CLI session and usage ergonomics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,7 @@ Current commands:
 
 - `altllm login-wallet`
 - `altllm logout`
+- `altllm status`
 - `altllm credit`
 - `altllm transactions`
 - `altllm usage-summary`
@@ -39,6 +40,7 @@ Common aliases:
 
 - `altllm balance` -> `altllm credit`
 - `altllm keys` -> `altllm list-api-keys`
+- `altllm whoami` -> `altllm status`
 
 Portal commands target the AltLLM Portal API. Cloud Claw commands target Cloud Claw through Portal SSO. The `altllm` CLI commands do not operate the OpenAI-compatible gateway; generated API keys are used there separately.
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Current commands:
 
 - `altllm login-wallet`
 - `altllm logout`
+- `altllm status`
 - `altllm credit`
 - `altllm transactions`
 - `altllm usage-summary`
@@ -57,6 +58,7 @@ Common aliases:
 
 - `altllm balance` -> `altllm credit`
 - `altllm keys` -> `altllm list-api-keys`
+- `altllm whoami` -> `altllm status`
 
 Portal commands target the AltLLM Portal API. Cloud Claw commands target Cloud Claw through Portal SSO. The `altllm` CLI commands do not operate the OpenAI-compatible gateway; generated API keys are used there separately.
 
@@ -308,6 +310,7 @@ Notes:
 - Automatic local signing is only allowed for the default production Portal API or loopback hosts. For other hosts, use `--prepare` and sign externally.
 - The current Portal backend still validates EVM addresses and Ethereum-style signatures.
 - If you run `login-wallet` without a local private key or `--signature`, it now returns a challenge payload instead of failing immediately.
+- Use `node dist/cli.js status` or `node dist/cli.js whoami` to inspect the saved session user and target URL without exposing the token.
 
 ## API Keys
 
@@ -464,24 +467,21 @@ View daily usage history:
 
 ```bash
 node dist/cli.js usage-timeline \
-  --base-url https://platform-api.altllm.ai \
-  --month 2026-03
+  --base-url https://platform-api.altllm.ai
 ```
 
 View usage by model:
 
 ```bash
 node dist/cli.js usage-by-model \
-  --base-url https://platform-api.altllm.ai \
-  --month 2026-03
+  --base-url https://platform-api.altllm.ai
 ```
 
 View usage by API key:
 
 ```bash
 node dist/cli.js usage-by-key \
-  --base-url https://platform-api.altllm.ai \
-  --month 2026-03
+  --base-url https://platform-api.altllm.ai
 ```
 
 ## Payments

--- a/docs/portal-cli-staging-prod-test-plan.md
+++ b/docs/portal-cli-staging-prod-test-plan.md
@@ -169,18 +169,18 @@ real on-chain payment without explicit approval.
 
 ## Functional Test Matrix
 
-Run these commands per user with that user's session file. Set the date range to
-the current UTC month unless the test is intentionally targeting another period:
+Run these commands per user with that user's session file. Usage commands
+default to the current UTC month unless the test intentionally passes another
+period:
 
 ```bash
-START_DATE="$(date -u +%Y-%m-01)"
-END_DATE="$(date -u +%F)"
+node dist/cli.js status --base-url "$BASE_URL" --session-file "$SESSION"
 node dist/cli.js credit --base-url "$BASE_URL" --session-file "$SESSION"
 node dist/cli.js transactions --base-url "$BASE_URL" --session-file "$SESSION"
 node dist/cli.js usage-summary --base-url "$BASE_URL" --session-file "$SESSION"
 node dist/cli.js usage-timeline --base-url "$BASE_URL" --session-file "$SESSION"
 node dist/cli.js usage-by-model --base-url "$BASE_URL" --session-file "$SESSION"
-node dist/cli.js usage-by-key --start-date "$START_DATE" --end-date "$END_DATE" --base-url "$BASE_URL" --session-file "$SESSION"
+node dist/cli.js usage-by-key --base-url "$BASE_URL" --session-file "$SESSION"
 node dist/cli.js list-api-keys --base-url "$BASE_URL" --session-file "$SESSION"
 ```
 

--- a/skills/altllm-portal-auth/SKILL.md
+++ b/skills/altllm-portal-auth/SKILL.md
@@ -23,6 +23,7 @@ Wallet login and session bootstrap for the local `altllm` CLI, including externa
 | `login-wallet --private-key <hex> --allow-unsafe-private-key-argv` | Sign in with an inline private key when argv exposure is explicitly accepted |
 | `login-wallet --prepare` | Fetch a challenge for external signing |
 | `login-wallet --nonce <nonce> --signature <sig>` | Verify an externally signed challenge and save the session |
+| `status` | Show saved Portal session user and target URL status without exposing the token |
 | `logout` | Remove the local saved Portal session file |
 
 ## Rules
@@ -35,6 +36,7 @@ Wallet login and session bootstrap for the local `altllm` CLI, including externa
 - For non-default, non-loopback API hosts, prefer `--prepare` and external signing instead of local auto-signing.
 - Current backend support is still limited to EVM addresses and Ethereum-style signatures.
 - Save the resulting session to `~/.altllm/portal-cli-session.json` unless overridden.
+- Use `status` or its `whoami` alias to confirm the saved user and target URL before running live commands.
 - `logout` only removes the local session file. It does not revoke API keys.
 
 ## Reference

--- a/skills/altllm-portal-auth/references/cli-reference.md
+++ b/skills/altllm-portal-auth/references/cli-reference.md
@@ -68,6 +68,16 @@ Representative stdout:
 
 This flow is intended for wallets or wallet providers that sign externally, such as Privy.
 
+### Inspect saved session
+
+```bash
+node dist/cli.js status
+```
+
+Alias: `node dist/cli.js whoami`
+
+`status` prints the saved Portal user, saved session origin, requested target origin, and whether the CLI would be allowed to forward the saved session token to that target. It never prints the session token.
+
 ### Verify externally signed challenge
 
 ```bash

--- a/skills/altllm-portal-billing/SKILL.md
+++ b/skills/altllm-portal-billing/SKILL.md
@@ -33,8 +33,8 @@ Balance, promo, transaction history, and usage analytics for the local `altllm` 
 - `credit` is the current CLI inspection path for plan/model-access metadata returned by Portal, including Business/Flex fields such as `subscription_tier: "flex"` when present.
 - `transactions` supports `--page`, `--limit`, and `--type`.
 - `usage-summary` currently reflects the current calendar month only.
-- `usage-timeline` and `usage-by-model` support either `--month` or a complete explicit date range.
-- `usage-by-key` supports either `--month` or a complete explicit date range.
+- `usage-timeline`, `usage-by-model`, and `usage-by-key` default to the current UTC month when no date flags are passed.
+- Usage commands support either `--month` or a complete explicit date range.
 - `balance` is an alias for `credit`.
 
 ## Reference

--- a/skills/altllm-portal-billing/references/cli-reference.md
+++ b/skills/altllm-portal-billing/references/cli-reference.md
@@ -55,24 +55,21 @@ This endpoint currently returns the current calendar-month summary.
 
 ```bash
 node dist/cli.js usage-timeline \
-  --base-url https://platform-api.altllm.ai \
-  --month 2026-03
+  --base-url https://platform-api.altllm.ai
 ```
 
 ### Usage by model
 
 ```bash
 node dist/cli.js usage-by-model \
-  --base-url https://platform-api.altllm.ai \
-  --month 2026-03
+  --base-url https://platform-api.altllm.ai
 ```
 
 ### Usage by key
 
 ```bash
 node dist/cli.js usage-by-key \
-  --base-url https://platform-api.altllm.ai \
-  --month 2026-03
+  --base-url https://platform-api.altllm.ai
 ```
 
 ## Notes
@@ -80,5 +77,5 @@ node dist/cli.js usage-by-key \
 - `credit` and `redeem-promo` pass through the API response body unchanged.
 - This repo does not implement plan billing logic or bypass Portal/Gateway model-access checks.
 - Transaction history and usage analytics are useful for validating gateway metering behavior.
-- `usage-timeline` and `usage-by-model` accept either `--month` or a complete `--start-date` / `--end-date` range, but not both.
-- `usage-by-key` accepts either `--month` or a complete `--start-date` / `--end-date` range, but not both.
+- `usage-timeline`, `usage-by-model`, and `usage-by-key` default to the current UTC month.
+- Usage commands accept either `--month` or a complete `--start-date` / `--end-date` range, but not both.

--- a/skills/altllm-portal-cli/references/skill-map.md
+++ b/skills/altllm-portal-cli/references/skill-map.md
@@ -6,7 +6,7 @@ This file maps local CLI commands to the focused repo-local skills.
 
 | Skill | Commands | Notes |
 |---|---|---|
-| `altllm-portal-auth` | `login-wallet` | Local signing, challenge preparation, external signature verification |
+| `altllm-portal-auth` | `login-wallet`, `status`, `logout` | Local signing, challenge preparation, external signature verification, saved-session inspection |
 | `altllm-portal-api-keys` | `list-api-keys`, `create-api-key`, `get-api-key`, `update-api-key`, `revoke-api-key` | Keys are for the OpenAI-compatible gateway; Flex-only `altllm-flex-*` model IDs are valid allowlist entries when backend access permits |
 | `altllm-portal-billing` | `credit`, `redeem-promo`, `transactions`, `usage-summary`, `usage-timeline`, `usage-by-model`, `usage-by-key` | Mostly raw Portal API JSON responses; use `credit` for returned plan/model-access metadata such as `subscription_tier` |
 | `altllm-portal-payments` | `topup-crypto`, `payment-status`, `pay-payment-link` | Includes direct-payment guardrails, supported automatic payment currencies, and credit top-up discount-code metadata |
@@ -17,6 +17,7 @@ This file maps local CLI commands to the focused repo-local skills.
   - [src/cli.ts](../../../src/cli.ts)
 - Auth flow:
   - [src/commands/login-wallet.ts](../../../src/commands/login-wallet.ts)
+  - [src/commands/status.ts](../../../src/commands/status.ts)
   - [src/lib/wallet.ts](../../../src/lib/wallet.ts)
 - API key flow:
   - [src/lib/keys.ts](../../../src/lib/keys.ts)

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -25,6 +25,7 @@ import { logout } from "./commands/logout.js";
 import { payPaymentLink } from "./commands/pay-payment-link.js";
 import { redeemPromo } from "./commands/redeem-promo.js";
 import { revokeApiKey } from "./commands/revoke-api-key.js";
+import { status } from "./commands/status.js";
 import { paymentStatus, topupCrypto } from "./commands/topup-crypto.js";
 import { updateApiKey } from "./commands/update-api-key.js";
 import { transactions } from "./commands/transactions.js";
@@ -112,9 +113,11 @@ program
 Common aliases:
   altllm balance            alias for credit
   altllm keys               alias for list-api-keys
+  altllm whoami             alias for status
 
 Examples:
   altllm login-wallet --wallet-address 0x... --private-key-env ALTLLM_WALLET_PRIVATE_KEY
+  altllm status
   altllm balance
   altllm keys
   altllm usage-by-key --month 2026-05
@@ -161,6 +164,21 @@ program
   .action(async (options) => {
     await logout({
       sessionFile: options.sessionFile,
+    });
+  });
+
+program
+  .command("status")
+  .alias("whoami")
+  .description("Show saved Portal session user and target URL status")
+  .option("--base-url <url>", "Portal API base URL to compare with the saved session")
+  .option("--session-file <path>", "Path to the saved Portal session", DEFAULT_SESSION_FILE)
+  .option("--allow-token-host-mismatch", PORTAL_TOKEN_HOST_MISMATCH_OPTION, false)
+  .action(async (options) => {
+    await status({
+      baseUrl: options.baseUrl,
+      sessionFile: options.sessionFile,
+      allowTokenHostMismatch: Boolean(options.allowTokenHostMismatch),
     });
   });
 

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -1,0 +1,59 @@
+import {
+  canonicalizeOrigin,
+  normalizeBaseUrl,
+  requireSecureNonLocalBaseUrl,
+} from "../lib/api.js";
+import { writeJson } from "../lib/keys.js";
+import { DEFAULT_SESSION_FILE, loadSession } from "../lib/session.js";
+
+export interface StatusOptions {
+  baseUrl?: string;
+  sessionFile: string;
+  allowTokenHostMismatch?: boolean;
+}
+
+export async function status(options: StatusOptions): Promise<void> {
+  const sessionFile = options.sessionFile || DEFAULT_SESSION_FILE;
+  const session = await loadSession(sessionFile);
+  const sessionBaseUrl = normalizeBaseUrl(session.baseUrl);
+  const targetBaseUrl = normalizeBaseUrl(options.baseUrl || session.baseUrl);
+  const sessionOrigin = canonicalizeOrigin(sessionBaseUrl);
+  const targetOrigin = canonicalizeOrigin(targetBaseUrl);
+  const targetMatchesSession = targetOrigin === sessionOrigin;
+  let secureForSessionToken = true;
+  let tokenForwardingError: string | null = null;
+
+  try {
+    requireSecureNonLocalBaseUrl(targetBaseUrl, "the saved Portal session token");
+  } catch (error) {
+    secureForSessionToken = false;
+    tokenForwardingError =
+      error instanceof Error && error.message ? error.message : String(error);
+  }
+
+  writeJson({
+    ok: true,
+    authenticated: true,
+    sessionFile,
+    user: {
+      id: session.user.id,
+      email: session.user.email,
+      name: session.user.name ?? null,
+    },
+    session: {
+      baseUrl: sessionBaseUrl,
+      origin: sessionOrigin,
+    },
+    target: {
+      baseUrl: targetBaseUrl,
+      origin: targetOrigin,
+      matchesSession: targetMatchesSession,
+      secureForSessionToken,
+      tokenHostMismatchAllowed: Boolean(options.allowTokenHostMismatch),
+      tokenForwardingAllowed:
+        secureForSessionToken &&
+        (targetMatchesSession || Boolean(options.allowTokenHostMismatch)),
+      tokenForwardingError,
+    },
+  });
+}

--- a/src/commands/usage-by-key.ts
+++ b/src/commands/usage-by-key.ts
@@ -1,5 +1,8 @@
 import { requestJson } from "../lib/api.js";
-import { appendRequiredDateRangeOrMonthParams } from "../lib/history.js";
+import {
+  appendRequiredDateRangeOrMonthParams,
+  formatUtcMonth,
+} from "../lib/history.js";
 import { resolvePortalContext, writeJson } from "../lib/keys.js";
 import { DEFAULT_SESSION_FILE } from "../lib/session.js";
 
@@ -14,11 +17,17 @@ export interface UsageByKeyOptions {
 
 export async function usageByKey(options: UsageByKeyOptions): Promise<void> {
   const searchParams = new URLSearchParams();
-  appendRequiredDateRangeOrMonthParams(searchParams, {
-    startDate: options.startDate,
-    endDate: options.endDate,
-    month: options.month,
-  });
+  appendRequiredDateRangeOrMonthParams(
+    searchParams,
+    {
+      startDate: options.startDate,
+      endDate: options.endDate,
+      month: options.month,
+    },
+    {
+      defaultMonth: formatUtcMonth(),
+    }
+  );
 
   const { baseUrl, token } = await resolvePortalContext({
     baseUrl: options.baseUrl,

--- a/src/commands/usage-by-model.ts
+++ b/src/commands/usage-by-model.ts
@@ -1,5 +1,5 @@
 import { requestJson } from "../lib/api.js";
-import { appendMonthOrDateRangeParams } from "../lib/history.js";
+import { appendMonthOrDateRangeParams, formatUtcMonth } from "../lib/history.js";
 import { resolvePortalContext, writeJson } from "../lib/keys.js";
 import { DEFAULT_SESSION_FILE } from "../lib/session.js";
 
@@ -14,11 +14,17 @@ export interface UsageByModelOptions {
 
 export async function usageByModel(options: UsageByModelOptions): Promise<void> {
   const searchParams = new URLSearchParams();
-  appendMonthOrDateRangeParams(searchParams, {
-    startDate: options.startDate,
-    endDate: options.endDate,
-    month: options.month,
-  });
+  appendMonthOrDateRangeParams(
+    searchParams,
+    {
+      startDate: options.startDate,
+      endDate: options.endDate,
+      month: options.month,
+    },
+    {
+      defaultMonth: formatUtcMonth(),
+    }
+  );
 
   const { baseUrl, token } = await resolvePortalContext({
     baseUrl: options.baseUrl,

--- a/src/commands/usage-timeline.ts
+++ b/src/commands/usage-timeline.ts
@@ -1,5 +1,5 @@
 import { requestJson } from "../lib/api.js";
-import { appendMonthOrDateRangeParams } from "../lib/history.js";
+import { appendMonthOrDateRangeParams, formatUtcMonth } from "../lib/history.js";
 import { resolvePortalContext, writeJson } from "../lib/keys.js";
 import { DEFAULT_SESSION_FILE } from "../lib/session.js";
 
@@ -14,11 +14,17 @@ export interface UsageTimelineOptions {
 
 export async function usageTimeline(options: UsageTimelineOptions): Promise<void> {
   const searchParams = new URLSearchParams();
-  appendMonthOrDateRangeParams(searchParams, {
-    startDate: options.startDate,
-    endDate: options.endDate,
-    month: options.month,
-  });
+  appendMonthOrDateRangeParams(
+    searchParams,
+    {
+      startDate: options.startDate,
+      endDate: options.endDate,
+      month: options.month,
+    },
+    {
+      defaultMonth: formatUtcMonth(),
+    }
+  );
 
   const { baseUrl, token } = await resolvePortalContext({
     baseUrl: options.baseUrl,

--- a/src/lib/history.ts
+++ b/src/lib/history.ts
@@ -3,6 +3,12 @@ import { CliError } from "./api.js";
 export const TRANSACTION_FILTER_TYPES = ["all", "credit", "usage", "refund"] as const;
 export type TransactionFilterType = (typeof TRANSACTION_FILTER_TYPES)[number];
 
+export function formatUtcMonth(value = new Date()): string {
+  const year = value.getUTCFullYear();
+  const month = String(value.getUTCMonth() + 1).padStart(2, "0");
+  return `${year}-${month}`;
+}
+
 function normalizeMonth(value: string): string {
   const month = value.trim();
   const match = /^(\d{4})-(\d{2})$/.exec(month);
@@ -105,7 +111,8 @@ export function appendDateRangeParams(
 
 export function appendMonthOrDateRangeParams(
   searchParams: URLSearchParams,
-  params: { startDate?: string; endDate?: string; month?: string }
+  params: { startDate?: string; endDate?: string; month?: string },
+  options: { defaultMonth?: string } = {}
 ): void {
   const hasMonth = params.month !== undefined;
   const hasStartDate = params.startDate !== undefined;
@@ -117,6 +124,11 @@ export function appendMonthOrDateRangeParams(
 
   if (hasStartDate !== hasEndDate) {
     throw new CliError("Provide both --start-date and --end-date for an explicit date range.");
+  }
+
+  if (!hasMonth && !hasStartDate && !hasEndDate && options.defaultMonth !== undefined) {
+    searchParams.set("month", normalizeMonth(options.defaultMonth));
+    return;
   }
 
   appendDateRangeParams(searchParams, params);
@@ -142,7 +154,8 @@ export function appendRequiredDateRangeParams(
 
 export function appendRequiredDateRangeOrMonthParams(
   searchParams: URLSearchParams,
-  params: { startDate?: string; endDate?: string; month?: string }
+  params: { startDate?: string; endDate?: string; month?: string },
+  options: { defaultMonth?: string } = {}
 ): void {
   const hasMonth = params.month !== undefined;
   const hasStartDate = params.startDate !== undefined;
@@ -154,6 +167,13 @@ export function appendRequiredDateRangeOrMonthParams(
 
   if (params.month !== undefined) {
     const { startDate, endDate } = monthToDateRange(params.month);
+    searchParams.set("start_date", startDate);
+    searchParams.set("end_date", endDate);
+    return;
+  }
+
+  if (!hasStartDate && !hasEndDate && options.defaultMonth !== undefined) {
+    const { startDate, endDate } = monthToDateRange(options.defaultMonth);
     searchParams.set("start_date", startDate);
     searchParams.set("end_date", endDate);
     return;

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -39,6 +39,9 @@ test("root help highlights aliases and common examples", async () => {
   assert.equal(result.code, 0);
   assert.match(result.stdout, /Common aliases:/);
   assert.match(result.stdout, /altllm balance\s+alias for credit/);
+  assert.match(result.stdout, /altllm whoami\s+alias for status/);
+  assert.match(result.stdout, /status\|whoami/);
+  assert.match(result.stdout, /altllm status/);
   assert.match(result.stdout, /altllm usage-by-key --month 2026-05/);
 });
 

--- a/test/history.test.ts
+++ b/test/history.test.ts
@@ -8,6 +8,7 @@ import {
   appendPaginationParams,
   appendRequiredDateRangeOrMonthParams,
   appendRequiredDateRangeParams,
+  formatUtcMonth,
   parseTransactionFilterType,
 } from "../src/lib/history.js";
 
@@ -88,6 +89,14 @@ test("appendMonthOrDateRangeParams rejects ambiguous or partial ranges", () => {
   );
 });
 
+test("appendMonthOrDateRangeParams can default to a UTC month", () => {
+  const searchParams = new URLSearchParams();
+
+  appendMonthOrDateRangeParams(searchParams, {}, { defaultMonth: "2024-02" });
+
+  assert.equal(searchParams.get("month"), "2024-02");
+});
+
 test("appendRequiredDateRangeParams requires both dates", () => {
   assertCliError(
     () => appendRequiredDateRangeParams(new URLSearchParams(), {}),
@@ -109,6 +118,23 @@ test("appendRequiredDateRangeOrMonthParams expands month shortcuts", () => {
 
   assert.equal(searchParams.get("start_date"), "2024-02-01");
   assert.equal(searchParams.get("end_date"), "2024-02-29");
+});
+
+test("appendRequiredDateRangeOrMonthParams can default to a month range", () => {
+  const searchParams = new URLSearchParams();
+
+  appendRequiredDateRangeOrMonthParams(
+    searchParams,
+    {},
+    { defaultMonth: "2024-02" }
+  );
+
+  assert.equal(searchParams.get("start_date"), "2024-02-01");
+  assert.equal(searchParams.get("end_date"), "2024-02-29");
+});
+
+test("formatUtcMonth formats the month in UTC", () => {
+  assert.equal(formatUtcMonth(new Date("2024-12-31T23:59:59Z")), "2024-12");
 });
 
 test("appendRequiredDateRangeOrMonthParams rejects missing or ambiguous ranges", () => {

--- a/test/portal-api.test.ts
+++ b/test/portal-api.test.ts
@@ -1,0 +1,173 @@
+import assert from "node:assert/strict";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import test from "node:test";
+
+import { status } from "../src/commands/status.js";
+import { usageByKey } from "../src/commands/usage-by-key.js";
+import { usageByModel } from "../src/commands/usage-by-model.js";
+import { usageTimeline } from "../src/commands/usage-timeline.js";
+import { formatUtcMonth } from "../src/lib/history.js";
+import type { PortalSession } from "../src/lib/session.js";
+
+interface CapturedRequest {
+  method: string | undefined;
+  url: string | undefined;
+  authorization: string | undefined;
+}
+
+async function writeSession(baseUrl: string): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "altllm-test-"));
+  const sessionFile = join(dir, "session.json");
+  const session: PortalSession = {
+    baseUrl,
+    token: "portal-test-token",
+    user: {
+      id: "user_123",
+      email: "user@example.com",
+      name: "Test User",
+    },
+  };
+
+  await writeFile(sessionFile, JSON.stringify(session), "utf8");
+  return sessionFile;
+}
+
+async function captureJson(fn: () => Promise<void>): Promise<Record<string, unknown>> {
+  const originalWrite = process.stdout.write;
+  let output = "";
+  process.stdout.write = ((chunk: string | Uint8Array): boolean => {
+    output += typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8");
+    return true;
+  }) as typeof process.stdout.write;
+
+  try {
+    await fn();
+  } finally {
+    process.stdout.write = originalWrite;
+  }
+
+  return JSON.parse(output) as Record<string, unknown>;
+}
+
+async function withMockPortal(
+  handler: (request: IncomingMessage, response: ServerResponse) => void,
+  fn: (baseUrl: string, requests: CapturedRequest[]) => Promise<void>
+): Promise<void> {
+  const requests: CapturedRequest[] = [];
+  const server = createServer((request, response) => {
+    requests.push({
+      method: request.method,
+      url: request.url,
+      authorization: request.headers.authorization,
+    });
+    handler(request, response);
+  });
+
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", resolve);
+  });
+
+  const address = server.address();
+  assert(address && typeof address === "object");
+
+  try {
+    await fn(`http://127.0.0.1:${address.port}`, requests);
+  } finally {
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+function currentMonthRange(): { startDate: string; endDate: string } {
+  const month = formatUtcMonth();
+  const [yearText, monthText] = month.split("-");
+  const year = Number(yearText);
+  const monthNumber = Number(monthText);
+  const lastDay = new Date(Date.UTC(year, monthNumber, 0)).getUTCDate();
+
+  return {
+    startDate: `${month}-01`,
+    endDate: `${month}-${String(lastDay).padStart(2, "0")}`,
+  };
+}
+
+test("usage commands default to the current UTC month and send bearer auth", async () => {
+  await withMockPortal(
+    (_request, response) => {
+      response.setHeader("Content-Type", "application/json");
+      response.end(JSON.stringify({ ok: true }));
+    },
+    async (baseUrl, requests) => {
+      const sessionFile = await writeSession(baseUrl);
+      await captureJson(() =>
+        usageTimeline({
+          baseUrl,
+          sessionFile,
+        })
+      );
+      await captureJson(() =>
+        usageByModel({
+          baseUrl,
+          sessionFile,
+        })
+      );
+      await captureJson(() =>
+        usageByKey({
+          baseUrl,
+          sessionFile,
+        })
+      );
+
+      const month = formatUtcMonth();
+      const range = currentMonthRange();
+      assert.deepEqual(
+        requests.map((request) => request.url),
+        [
+          `/api/usage/timeline?month=${month}`,
+          `/api/usage/by-model?month=${month}`,
+          `/api/usage/by-key?start_date=${range.startDate}&end_date=${range.endDate}`,
+        ]
+      );
+      assert.deepEqual(
+        requests.map((request) => request.authorization),
+        ["Bearer portal-test-token", "Bearer portal-test-token", "Bearer portal-test-token"]
+      );
+    }
+  );
+});
+
+test("status reports session identity and target safety without exposing token", async () => {
+  const sessionFile = await writeSession("https://platform-api.altllm.ai");
+  const result = await captureJson(() =>
+    status({
+      baseUrl: "http://api.altllm.example",
+      sessionFile,
+    })
+  );
+
+  assert.equal(result.authenticated, true);
+  assert.deepEqual(result.user, {
+    id: "user_123",
+    email: "user@example.com",
+    name: "Test User",
+  });
+  assert.equal(JSON.stringify(result).includes("portal-test-token"), false);
+  assert.deepEqual(result.session, {
+    baseUrl: "https://platform-api.altllm.ai",
+    origin: "https://platform-api.altllm.ai",
+  });
+  assert.deepEqual(result.target, {
+    baseUrl: "http://api.altllm.example",
+    origin: "http://api.altllm.example",
+    matchesSession: false,
+    secureForSessionToken: false,
+    tokenHostMismatchAllowed: false,
+    tokenForwardingAllowed: false,
+    tokenForwardingError:
+      "Refusing to send the saved Portal session token to insecure non-local base URL http://api.altllm.example. Use https:// for non-local targets.",
+  });
+});


### PR DESCRIPTION
## Summary
- add a JSON status/whoami command for saved Portal session identity and target-token safety
- default usage-timeline, usage-by-model, and usage-by-key to the current UTC month when date flags are omitted
- add mock Portal HTTP coverage for usage query params and bearer auth
- update README, skill docs, and staging test plan for the new workflow

## Tests
- npm test
- npm run typecheck
- npm run build