### PR TITLE
Add x402 skill guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -73,6 +73,8 @@ Commands that reuse a saved Portal session token, or forward that token to Cloud
   - focused balance/history/usage skill
 - `skills/altllm-portal-payments/`
   - focused payment-link and direct-payment skill
+- `skills/altllm-x402/`
+  - focused x402 Portal credit top-up and Binance B402 skill
 - `skills/_shared/`
   - shared preflight and environment notes reused by the focused skills
 
@@ -83,6 +85,8 @@ Commands that reuse a saved Portal session token, or forward that token to Cloud
 - Keep command output machine-readable JSON.
 - Fail fast on unsupported chains or `pay_currency` values.
 - Do not silently downgrade from direct payment mode to hosted checkout mode.
+- Keep NOWPayments payment-link flows separate from x402 Portal quote/settle flows.
+- For current x402 work, match `alt-research/altllm`: Binance B402, `bsc`/`eip155:56`, and normally `usdt`.
 - Do not print private keys or persist them outside user-controlled environment variables or files.
 
 ## Validation
@@ -124,6 +128,16 @@ Direct payment execution currently assumes the API returns:
 - `pay_currency`
 
 Only supported EVM-compatible `pay_currency` values should be auto-paid. Unsupported values must return a clear error.
+
+## x402 Constraints
+
+x402 support in this repository is currently skill/documentation guidance, not an `altllm` CLI command surface. The implementation source of truth is `alt-research/altllm`.
+
+- Do not describe NOWPayments hosted/direct payment links as x402.
+- Current AltLLM x402 top-ups use Portal API `/api/billing/x402/quote`, `/api/billing/x402/settle`, and `/api/billing/x402/{payment_id}/cancel`.
+- Quote BNB Chain mainnet with `network: "bsc"` and usually `asset: "usdt"` unless the main AltLLM repo changes.
+- Keep Portal session tokens and generated AltLLM gateway API keys separate from x402 wallet payment credentials.
+- If an x402-protected service calls the AltLLM gateway, keep the AltLLM API key server-side.
 
 ## Security
 

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -21,6 +21,7 @@ Main areas:
 - balance, transaction history, promo redemption, and usage reporting
 - API key creation and listing
 - crypto top-up payment link creation and direct-payment execution
+- x402 Portal credit top-up guidance for BSC/USDT wallet payments
 - Cloud Claw VM deployment and lifecycle operations
 
 Typical end-to-end workflows it can complete:
@@ -29,6 +30,7 @@ Typical end-to-end workflows it can complete:
 - check credit, inspect recent transactions, and explain where balance changed
 - redeem a promo code and verify the new balance
 - create a direct Base payment link and, if a funded wallet key is available, pay it
+- create an x402 quote for BSC/USDT credits, settle it after wallet signing, and verify balance
 - deploy a PicoClaw or OpenClaw VM, confirm status, stop it, and delete it
 
 ## What To Ask For
@@ -42,6 +44,8 @@ Examples:
 - "Create an API key for altllm-basic and test it with say hi"
 - "Redeem this promo code"
 - "Create a Base USDC top-up link for 5 dollars"
+- "Create an x402 USDT top-up quote with this discount code"
+- "Settle this x402 payment payload and check my balance"
 - "Deploy a PicoClaw with this Telegram bot token"
 - "Stop that VM and delete it after it is terminated"
 
@@ -63,6 +67,12 @@ Useful inputs by task:
   - target amount in USD credit
   - chain/pay currency such as `usdcbase`
   - a funded wallet private key via `--private-key-env`, `--private-key-file`, or guarded `--private-key` if you want automatic payment
+- x402:
+  - Portal API origin and authenticated Portal bearer token source
+  - credit amount in USD
+  - network and asset, normally `bsc` and `usdt`
+  - optional promo or discount code
+  - wallet signing method, or a signed `payment_payload` file for settlement
 - PicoClaw or Ottie deployment:
   - deployment name, or permission to generate one
   - Telegram bot token
@@ -113,6 +123,8 @@ There are a few important constraints worth knowing up front.
   - `revoke-api-key`
   - list and create still work
 - direct payment is only automatic when an EVM-compatible supported `pay_currency` is returned and the wallet has enough on-chain balance
+- the current `altllm` CLI does not execute x402 payments; current x402 support lives in the main AltLLM Portal API
+- NOWPayments top-up links are separate from AltLLM Portal x402 quote/settle flows
 - Base USDC top-ups require actual `USDC` on Base, not just ETH for gas
 - `topup-crypto` currently requires `--amount >= 0.5`
 - payment-link lookup currently only scans the most recent `100` Portal payment links
@@ -133,6 +145,8 @@ These are good patterns for future tasks:
 - "Create a new API key named X for models Y and Z"
 - "Create a Base payment link for N dollars and tell me the pay address"
 - "Pay this payment link with the wallet key I provide and wait for settlement"
+- "Create an x402 quote for $100 credits with code LAUNCH20"
+- "Debug why this x402 settlement is failing with the Binance facilitator"
 - "Deploy a PicoClaw with this bot token, confirm it is running, then show me the bot username"
 - "Stop this VM, wait until terminated, then delete it"
 
@@ -146,6 +160,7 @@ If you want to inspect the local skill layout:
 - [skills/altllm-portal-api-keys/SKILL.md](./skills/altllm-portal-api-keys/SKILL.md): API key flow
 - [skills/altllm-portal-billing/SKILL.md](./skills/altllm-portal-billing/SKILL.md): billing and usage
 - [skills/altllm-portal-payments/SKILL.md](./skills/altllm-portal-payments/SKILL.md): payment flow
+- [skills/altllm-x402/SKILL.md](./skills/altllm-x402/SKILL.md): x402 Portal credit top-up guidance
 - [skills/cloud-claw/SKILL.md](./skills/cloud-claw/SKILL.md): umbrella Cloud Claw skill
 - [skills/cloud-claw-launch-agent/SKILL.md](./skills/cloud-claw-launch-agent/SKILL.md): VM launch flow
 - [skills/cloud-claw-manage-vm/SKILL.md](./skills/cloud-claw-manage-vm/SKILL.md): VM lifecycle flow

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ If you want a task-oriented guide for what an agent can do with these skills, st
 
 - the **Portal API**, which handles user auth, wallet login, API keys, credit balance, billing history, promo redemption, and crypto payment links
 - the **OpenAI-compatible gateway**, which is where generated API keys are used to call AltLLM models
+- **x402 Portal credit top-ups**, where AltLLM Portal can quote and settle BSC/USDT wallet payments through Binance B402
 
 This repository is the **TypeScript CLI for the Portal side** of that platform. It is meant for operational tasks such as:
 
@@ -17,6 +18,7 @@ This repository is the **TypeScript CLI for the Portal side** of that platform. 
 - creating and managing Portal-issued API keys
 - checking balance, transactions, and usage history
 - creating and settling crypto top-up payments
+- documenting and operating x402 credit top-up flows implemented in the main AltLLM Portal
 
 This repository also includes **repo-local skills** for coding agents. Those skills are not runtime dependencies of AltLLM itself. They are structured guidance files that help agents choose the right commands, follow the right workflow, and avoid mixing up Portal operations with gateway usage.
 
@@ -129,7 +131,8 @@ evidence, revokes the key, and prints a redacted JSON report.
 | `altllm-portal-auth` | Wallet login, logout, and session bootstrap | Wallet challenge, local signing, external signature verification, local session removal |
 | `altllm-portal-api-keys` | Portal API key lifecycle | Create, inspect, disable, re-enable, or revoke API keys |
 | `altllm-portal-billing` | Balance, promo, transactions, and usage analytics | Credit balance, promo redemption, billing history, usage views |
-| `altllm-portal-payments` | Payment-link creation, polling, and direct payment execution | Crypto top-up, payment status, direct wallet payment |
+| `altllm-portal-payments` | NOWPayments link creation, polling, and direct payment execution | Crypto top-up links, payment status, direct wallet payment |
+| `altllm-x402` | x402 Portal credit top-up guidance | BSC/USDT quotes, discount top-ups, wallet signing, settlement |
 | `altllm-portal-cli` | Umbrella navigation skill | Workflows that span multiple domains |
 | `cloud-claw-launch-agent` | Launch a new AltClaw / OpenClaw / PicoClaw / Ottie VM | New deployment workflow through the local `cloud-claw-*` CLI commands |
 | `cloud-claw-manage-vm` | View and manage existing Cloud Claw VMs | List, inspect, start, stop, renew, logs, and dashboard |
@@ -154,6 +157,12 @@ Use this when the user wants current balance, billing transactions, or usage his
 `altllm-portal-payments` -> `altllm-portal-billing`
 
 Use this when the user needs to create a payment link, wait for settlement, and then confirm the resulting balance or usage changes.
+
+**Create and Settle x402 Credit Top-Up**
+
+`altllm-x402`
+
+Use this when the user needs to create an AltLLM Portal x402 quote, apply a discount code, submit a wallet-signed payment payload, cancel a quoted checkout, or debug Binance B402 facilitator errors. The current local `altllm` CLI does not expose these x402 endpoints.
 
 **Launch and Manage AltClaw**
 
@@ -600,7 +609,8 @@ node dist/cli.js login-wallet \
 - `skills/altllm-portal-auth/`: wallet login and challenge/signature flow
 - `skills/altllm-portal-api-keys/`: Portal API key lifecycle
 - `skills/altllm-portal-billing/`: balance, promo, transactions, and usage history
-- `skills/altllm-portal-payments/`: payment-link creation, polling, and direct payment
+- `skills/altllm-portal-payments/`: NOWPayments link creation, polling, and direct payment
+- `skills/altllm-x402/`: x402 Portal credit top-up and Binance B402 guidance
 - `skills/cloud-claw/`: umbrella skill for Cloud Claw workflows
 - `skills/cloud-claw-launch-agent/`: new deployment workflow for AltClaw / OpenClaw / PicoClaw / Ottie
 - `skills/cloud-claw-manage-vm/`: VM list, lifecycle, logs, renewals, and dashboard access

--- a/skills/altllm-portal-cli/SKILL.md
+++ b/skills/altllm-portal-cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: altllm-portal-cli
-description: Use this umbrella skill when the request spans multiple AltLLM Portal CLI domains, or when you need to navigate the local altllm CLI in this repository across auth, API keys, billing history, and payments.
+description: Use this umbrella skill when the request spans multiple AltLLM Portal CLI domains, or when you need to navigate the local altllm CLI in this repository across auth, API keys, billing history, NOWPayments payment links, and related x402 Portal top-up guidance.
 user-invocable: true
 ---
 
@@ -28,7 +28,8 @@ This skill family is specifically about the **Portal CLI workflow** in this repo
 | `altllm-portal-auth` | Wallet login and session bootstrap | Wallet challenge, signature verification, login troubleshooting |
 | `altllm-portal-api-keys` | Portal API key lifecycle | Create, inspect, disable, re-enable, or revoke API keys |
 | `altllm-portal-billing` | Balance, promo, transactions, and usage analytics | Credit balance, promo redemption, billing history, usage views |
-| `altllm-portal-payments` | Payment-link creation, polling, and direct payment execution | Crypto top-up, payment status, direct wallet payment |
+| `altllm-portal-payments` | NOWPayments link creation, polling, and direct payment execution | Crypto top-up links, payment status, direct wallet payment |
+| `altllm-x402` | Portal x402 credit top-up guidance | BSC/USDT x402 quotes, discount top-ups, wallet signing, settlement, facilitator errors |
 
 ## Plan Awareness
 
@@ -43,6 +44,7 @@ This skill family is specifically about the **Portal CLI workflow** in this repo
   - login -> create API key -> verify gateway use
   - credit -> transactions -> usage analytics
   - top-up -> payment-status -> pay-payment-link
+  - x402 quote -> wallet signing -> settlement -> balance verification
 - Keep implementation and docs aligned when behavior changes.
 
 ## Reference

--- a/skills/altllm-portal-cli/references/skill-map.md
+++ b/skills/altllm-portal-cli/references/skill-map.md
@@ -9,7 +9,8 @@ This file maps local CLI commands to the focused repo-local skills.
 | `altllm-portal-auth` | `login-wallet` | Local signing, challenge preparation, external signature verification |
 | `altllm-portal-api-keys` | `list-api-keys`, `create-api-key`, `get-api-key`, `update-api-key`, `revoke-api-key` | Keys are for the OpenAI-compatible gateway; Flex-only `altllm-flex-*` model IDs are valid allowlist entries when backend access permits |
 | `altllm-portal-billing` | `credit`, `redeem-promo`, `transactions`, `usage-summary`, `usage-timeline`, `usage-by-model`, `usage-by-key` | Mostly raw Portal API JSON responses; use `credit` for returned plan/model-access metadata such as `subscription_tier` |
-| `altllm-portal-payments` | `topup-crypto`, `payment-status`, `pay-payment-link` | Includes direct-payment guardrails, supported automatic payment currencies, and credit top-up discount-code metadata |
+| `altllm-portal-payments` | `topup-crypto`, `payment-status`, `pay-payment-link` | Includes NOWPayments/direct-payment guardrails, supported automatic payment currencies, and credit top-up discount-code metadata |
+| `altllm-x402` | none in the current `altllm` CLI | Guidance for Portal x402 credit top-ups implemented in `alt-research/altllm`: `/api/billing/x402/quote`, `/settle`, and `/{payment_id}/cancel` |
 
 ## Repository Files
 
@@ -37,6 +38,9 @@ This file maps local CLI commands to the focused repo-local skills.
 - Payments:
   - [src/commands/topup-crypto.ts](../../../src/commands/topup-crypto.ts)
   - [src/commands/pay-payment-link.ts](../../../src/commands/pay-payment-link.ts)
+- x402:
+  - [skills/altllm-x402/SKILL.md](../../altllm-x402/SKILL.md)
+  - [skills/altllm-x402/references/protocol-reference.md](../../altllm-x402/references/protocol-reference.md)
 - Shared session and API wrapper:
   - [src/lib/session.ts](../../../src/lib/session.ts)
   - [src/lib/api.ts](../../../src/lib/api.ts)

--- a/skills/altllm-portal-payments/SKILL.md
+++ b/skills/altllm-portal-payments/SKILL.md
@@ -1,12 +1,14 @@
 ---
 name: altllm-portal-payments
-description: Use this skill when the user asks to create a crypto payment link, poll payment status, or execute a supported direct wallet payment through the AltLLM Portal CLI. Do NOT use for wallet login, API key management, or billing history.
+description: Use this skill when the user asks to create a NOWPayments crypto payment link, poll payment status, or execute a supported direct wallet payment through the AltLLM Portal CLI. Do NOT use for wallet login, API key management, billing history, or x402 credit top-ups.
 user-invocable: true
 ---
 
 # AltLLM Portal Payments
 
-Payment-link creation, settlement polling, and direct wallet payment flows for the local `altllm` CLI.
+NOWPayments payment-link creation, settlement polling, and direct wallet payment flows for the local `altllm` CLI.
+
+These payment links are separate from AltLLM Portal x402 credit top-ups. Use `altllm-x402` for `/api/billing/x402/quote` and `/settle` flows.
 
 ## Shared Setup
 

--- a/skills/altllm-portal-payments/references/cli-reference.md
+++ b/skills/altllm-portal-payments/references/cli-reference.md
@@ -64,6 +64,7 @@ Direct `--private-key` usage requires `--allow-unsafe-private-key-argv` because 
 
 ## Notes
 
+- NOWPayments payment links are not x402. Use `altllm-x402` for AltLLM Portal `/api/billing/x402/quote` and `/settle` credit top-ups.
 - `payment-status` and `pay-payment-link` currently only search the newest `100` Portal payment links.
 - Older payment links are not reachable from these CLI flows until the backend supports lookup by ID or older-page pagination.
 - Automatic payment requires `pay_address`, `pay_amount`, and `pay_currency` to be present in the API response.

--- a/skills/altllm-x402/SKILL.md
+++ b/skills/altllm-x402/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: altllm-x402
+description: Use this skill when the user asks to create, settle, debug, or document AltLLM Portal x402 credit top-ups, including Binance B402, BSC/USDT quotes, optional top-up discount codes, wallet signing, settlement, cancellation, and facilitator errors. Also use for future AltLLM x402 paid-resource design. Do NOT use for NOWPayments hosted/direct payment links; use altllm-portal-payments for those.
+user-invocable: true
+---
+
+# AltLLM x402
+
+x402 integration guidance for AltLLM Portal credit top-ups and related agent payment flows.
+
+The current `altllm` CLI in this repository does not expose x402 commands. The source implementation lives in `alt-research/altllm` as Portal API endpoints and a repo-local `altllm-discount-topup` helper skill.
+
+## When To Use
+
+Use this skill for:
+
+- quoting or settling an AltLLM Portal x402 credit top-up
+- using an x402 top-up discount code such as a fixed-value starter offer
+- helping a user approve, sign, or cancel an x402 checkout
+- debugging Binance B402 facilitator, `/supported`, `/verify`, or `/settle` errors
+- documenting the current AltLLM x402 implementation boundary
+- designing future AltLLM x402 paid-resource or pay-per-request flows
+
+## First Steps
+
+1. Read [references/protocol-reference.md](references/protocol-reference.md) for the current repo-local x402 notes.
+2. Confirm whether the task is current Portal top-up, future paid-resource design, or protocol debugging.
+3. For live implementation work, verify `alt-research/altllm` first because Portal x402 behavior and enabled assets are controlled there.
+4. Keep Portal bearer tokens, generated gateway API keys, and wallet payment credentials separate.
+
+## Guardrails
+
+- Do not describe NOWPayments hosted checkout or direct-payment links as x402.
+- Current AltLLM Portal x402 is a one-time credit top-up flow, not an `altllm` CLI command and not current gateway pay-per-request middleware.
+- Current staging/prod defaults target Binance B402 on BNB Chain mainnet: `network: "bsc"` with CAIP-2 alias `eip155:56`, normally `asset: "usdt"`.
+- Quote through `POST /api/billing/x402/quote`; settle through `POST /api/billing/x402/settle`; cancel quoted checkouts through `POST /api/billing/x402/{payment_id}/cancel`.
+- Use normal non-promo top-up amounts of `$5` or more unless the server-side promo flow explicitly allows a fixed smaller payable amount.
+- Use the Portal quote response as the source of truth for payable amount, token amount, `payment_requirement`, expiration, discount fields, and `payment_id`.
+- Do not submit settlement without explicit user approval unless a prior spend policy covers this exact amount, network, asset, and discount code.
+- Never invent or edit signed x402 payment payloads. Have a wallet or approved x402 client satisfy the returned `payment_requirement`.
+- Do not retry blindly with the same signed payload after facilitator verification or settlement fails.
+- Keep wallet private keys, Portal tokens, and signed payload JSON in env vars, protected files, or stdin. Do not print or pass them on argv.
+
+## Reference
+
+See [references/protocol-reference.md](references/protocol-reference.md) for AltLLM Portal endpoints, fields, runtime config, and troubleshooting.

--- a/skills/altllm-x402/references/protocol-reference.md
+++ b/skills/altllm-x402/references/protocol-reference.md
@@ -1,0 +1,169 @@
+# AltLLM x402 Protocol Reference
+
+Current as of 2026-06-15. Re-check `alt-research/altllm` before live implementation.
+
+Primary AltLLM source references:
+
+- AltLLM x402 design: https://github.com/alt-research/altllm/blob/main/docs/x402-payment-integration.md
+- Upstream agent skill: https://github.com/alt-research/altllm/blob/main/.agents/skills/altllm-discount-topup/SKILL.md
+- Portal service: https://github.com/alt-research/altllm/blob/main/portal/api/services/x402.py
+- Billing routes: https://github.com/alt-research/altllm/blob/main/portal/api/routes/billing.py
+- Billing models: https://github.com/alt-research/altllm/blob/main/portal/api/models/billing.py
+- GitOps config tests: https://github.com/alt-research/altllm/blob/main/tests/test_x402_gitops_staging_config.py
+- Binance Onchain Pay x402: https://developers.binance.com/docs/onchainpay-x402/introduction
+
+## AltLLM Boundary
+
+- The current `altllm` CLI in this repository does not expose x402 commands.
+- The current AltLLM implementation is a Portal credit top-up payment channel, not current gateway pay-per-request middleware.
+- NOWPayments payment links remain under `altllm-portal-payments`; x402 top-ups use separate Portal API endpoints.
+- Generated Portal API keys are for the OpenAI-compatible gateway at `https://api.altllm.ai/v1`; they are not x402 payment credentials.
+- If a future x402-protected service calls the AltLLM gateway, keep the gateway API key server-side.
+
+## Current Portal Flow
+
+Quote:
+
+```http
+POST /api/billing/x402/quote
+Authorization: Bearer <Portal token>
+Content-Type: application/json
+```
+
+```json
+{
+  "amount": "100",
+  "network": "bsc",
+  "asset": "usdt",
+  "promo_code": "OPTIONAL"
+}
+```
+
+The quote response includes:
+
+- `payment_id`
+- `status`
+- `amount`
+- `credit_amount`
+- `final_amount`
+- `currency`
+- `network`
+- `asset`
+- `pay_to`
+- `payment_requirement`
+- `expires_at`
+- optional discount fields: `promo_code`, `discount_percent`, `max_discount_amount`, `fixed_credit_amount`, `fixed_pay_amount`, `discount_amount`, `allowed_pay_currencies`
+
+Settle after the wallet or x402 client returns a signed payment payload:
+
+```http
+POST /api/billing/x402/settle
+Authorization: Bearer <Portal token>
+Content-Type: application/json
+```
+
+```json
+{
+  "payment_id": "<quote payment_id>",
+  "payment_payload": {
+    "x402Version": 2
+  }
+}
+```
+
+The actual `payment_payload` must come from the user's wallet or a compatible x402/B402 client. Do not fabricate it.
+
+Settle response fields include:
+
+- `payment_id`
+- `status`
+- `amount`
+- `credit_amount`
+- `final_amount`
+- `balance`
+- `transaction_id`
+- `settlement_id`
+- `tx_hash`
+- optional discount fields
+
+Cancel an unsubmitted quoted checkout:
+
+```http
+POST /api/billing/x402/{payment_id}/cancel
+Authorization: Bearer <Portal token>
+```
+
+## Current Network And Provider
+
+- Provider: Binance B402.
+- Staging facilitator URL: `https://qacb.sdtaop.com`.
+- Production facilitator URL: `https://cb.binanceapi.com`.
+- Current staging/prod network: `bsc`, aliased to CAIP-2 `eip155:56`.
+- Current staging/prod asset: `usdt`.
+- USDT BSC token address: `0x55d398326f99059fF775485246999027B3197955`.
+- Asset decimals: `18`.
+- Payment scheme: `exact`.
+- x402 version: `2`.
+- Default chart hardening allows `eip3009`; released staging/prod config also allows `permit2-exact` with an explicit spender allowlist.
+- Binance `/papi/v2/b402/supported` is the normal source of `payment_requirement.extra`.
+
+## Payment Requirement Notes
+
+- Portal builds a server-bound `payment_requirement`; agents should preserve it exactly.
+- For Binance B402 V2, Portal uses an `amount` field in token minor units rather than `maxAmountRequired`.
+- The requirement includes the normalized wire network, asset address, `payTo`, resource metadata, expiration, and provider `extra`.
+- Portal validates the returned payment payload against the quoted requirement, recipient, transfer amount, transfer method, and provider `extra`.
+- Portal hashes payment payloads and stores settlement identifiers/tx hashes for replay protection.
+
+## Agent Workflow
+
+1. Use an authenticated Portal bearer token, not a generated gateway API key.
+2. Create a quote with `amount`, `network: "bsc"`, `asset: "usdt"`, and optional `promo_code`. Use `$5` or more for normal non-promo top-ups unless the server-side promo flow explicitly allows a fixed smaller payable amount.
+3. Show the user the original credit amount, final payable amount, discount details, network, asset, pay-to address, and expiration.
+4. Get explicit approval before signing unless a prior spend policy covers this exact purchase.
+5. Have the wallet or approved x402 client satisfy the returned `payment_requirement`.
+6. Submit the signed `payment_payload` to `/api/billing/x402/settle`.
+7. Report `balance`, `settlement_id`, `tx_hash`, `payment_id`, and discount fields.
+
+Never pass Portal bearer tokens or signed payload JSON on argv. Use environment variables, protected files, or stdin.
+
+When working inside the main `alt-research/altllm` checkout, prefer the upstream helper for deterministic API calls:
+
+```bash
+python .agents/skills/altllm-discount-topup/scripts/x402_discount_topup.py quote \
+  --portal-url "$PORTAL_URL" \
+  --amount 100 \
+  --network bsc \
+  --asset usdt \
+  --promo-code "$DISCOUNT_CODE"
+```
+
+```bash
+python .agents/skills/altllm-discount-topup/scripts/x402_discount_topup.py settle \
+  --portal-url "$PORTAL_URL" \
+  --payment-id "$PAYMENT_ID" \
+  --payment-payload-file ./payment-payload.json
+```
+
+## Status Lifecycle
+
+- `quoted`: requirement created and still payable.
+- `verifying`: settlement is in progress.
+- `settled`: credits were granted exactly once.
+- `failed`: facilitator verification or settlement failed.
+- `expired`: quote expired, was canceled, or discount reservation is no longer active.
+
+## Troubleshooting
+
+- `503 x402 credit top-ups are not enabled`: target Portal environment is not configured for x402.
+- `503 Unable to fetch Binance B402 /supported metadata`: Portal egress, Binance credentials, or facilitator availability is blocking quote creation.
+- `400 Invalid discount code`: ask for a different code or continue without a promo.
+- `400` or `409 PENDING_PAYMENT`: the discount code is attached to an open checkout; settle it, cancel it, or let it expire.
+- `402` from settlement: facilitator verify/settle failed. Do not retry blindly with the same signed payload.
+- Wallet cannot sign/pay: confirm BNB Chain mainnet, USDT balance, EIP-3009 or Permit2 support, and any Permit2 allowance.
+- Wallet warns about a Permit2 spender: stop and surface the warning unless the spender is explicitly allowlisted and the user approves.
+- Failed or expired checkout: create a fresh quote before submitting another signed payload.
+
+## Future Paid-Resource x402
+
+Some AltLLM strategy docs discuss x402 pay-per-request APIs, MCP servers, or agent resources. Treat those as future design unless the target code implements them. For future work, keep the AltLLM gateway API key server-side and use x402 only for the buyer payment credential.


### PR DESCRIPTION
## Summary
- add a focused `altllm-x402` repo-local skill aligned with `alt-research/altllm` Portal x402 credit top-ups
- document Binance B402, BSC/USDT quote/settle/cancel endpoints, discount fields, wallet signing, status lifecycle, and facilitator troubleshooting
- update Portal payment and umbrella docs to distinguish NOWPayments links from x402 Portal quote/settle flows

## Validation
- checked `alt-research/altllm` `origin/main` source files: `.agents/skills/altllm-discount-topup`, `docs/x402-payment-integration.md`, `portal/api/services/x402.py`, `portal/api/routes/billing.py`, `portal/api/models/billing.py`, and x402 GitOps tests
- stale-term scan for old Base/generic x402 guidance
- git diff --check
- npm test
- npm run typecheck
- npm run build

Note: prior `npm install` reported existing GitHub audit findings on the default dependency set. The skill-creator quick validator rejects this repo’s existing `user-invocable` frontmatter convention, including for pre-existing skills.